### PR TITLE
fix: agregar dependencia get_current_user faltante en GET /instances/{instance_id}

### DIFF
--- a/backend/app/api/endpoints/instances.py
+++ b/backend/app/api/endpoints/instances.py
@@ -139,7 +139,8 @@ async def create_workflow_instance(
 
 @router.get("/{instance_id}", response_model=InstanceResponse)
 async def get_instance(
-    db_instance: WorkflowInstance = Depends(require_instance_access)
+    db_instance: WorkflowInstance = Depends(require_instance_access),
+    current_user: dict = Depends(get_current_user),
 ):
     """Get DAG instance details with role-based access control"""
     instance_id = db_instance.instance_id


### PR DESCRIPTION
## Summary

El endpoint `GET /api/v1/instances/{instance_id}` esta roto: usa `current_user.get("sub")` y `current_user.get("roles")` para el chequeo de permisos, pero nunca declara `current_user` como parametro/dependencia de FastAPI. Cualquier peticion devuelve **500 Internal Server Error** con `NameError: name 'current_user' is not defined` en los logs.

## Causa

En `backend/app/api/endpoints/instances.py:140-159`, la firma solo tiene:

```python
async def get_instance(
    db_instance: WorkflowInstance = Depends(require_instance_access)
):
```

pero el cuerpo referencia `current_user` que nunca se inyecta.

## Fix

Una linea: agregar la dependencia. `get_current_user` ya esta importado desde `auth.provider` en la linea 32.

```python
async def get_instance(
    db_instance: WorkflowInstance = Depends(require_instance_access),
    current_user: dict = Depends(get_current_user),
):
```

## Test plan

- [x] Reproducir el 500: GET /api/v1/instances/<id> con token admin devuelve NameError en logs
- [x] Aplicar el fix, reiniciar backend
- [x] Verificar 200 OK con token admin: endpoint devuelve instance_id, workflow_id, status, context completo
- [ ] Verificar 403 con token de otro usuario no-admin (logica intacta pero no reproducida en este PR)