### PR TITLE
feat: propagar TaskStatus.SKIP a descendientes para habilitar branching real con ShortCircuitOperator

### DIFF
--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -276,6 +276,7 @@ class WorkflowInstance(Document):
     # Progress tracking
     completed_steps: List[str] = Field(default_factory=list, description="List of completed step IDs")
     failed_steps: List[str] = Field(default_factory=list, description="List of failed step IDs")
+    skipped_steps: List[str] = Field(default_factory=list, description="List of skipped step IDs (short-circuit or cascaded)")
     pending_approvals: List[str] = Field(default_factory=list, description="Steps waiting for approval")
     task_states: Dict[str, Dict[str, Any]] = Field(default_factory=dict, description="Individual task state data including output_data")
     

--- a/backend/app/workflows/dag.py
+++ b/backend/app/workflows/dag.py
@@ -233,6 +233,7 @@ class DAGInstance:
         self.task_states: Dict[str, Any] = {}
         self.completed_tasks: Set[str] = set()
         self.failed_tasks: Set[str] = set()
+        self.skipped_tasks: Set[str] = set()
         
         # Timestamps
         self.created_at = datetime.utcnow()
@@ -253,17 +254,23 @@ class DAGInstance:
     def get_executable_tasks(self) -> List[str]:
         """
         Get tasks that can be executed now.
-        
+
+        A task is executable when all its upstream predecessors are resolved
+        (completed or skipped) and at least one upstream completed. Tasks whose
+        upstreams are ALL skipped are themselves skipped via propagate_skips().
+
         Returns:
             List of task IDs ready for execution
         """
         executable = []
-        
+
         for task_id in self.dag.tasks.keys():
-            # Skip if already completed or failed
-            if task_id in self.completed_tasks or task_id in self.failed_tasks:
+            # Skip if already completed, failed, or short-circuited
+            if (task_id in self.completed_tasks
+                    or task_id in self.failed_tasks
+                    or task_id in self.skipped_tasks):
                 continue
-            
+
             # Skip if currently executing (but NOT if waiting - waiting tasks can be resumed)
             if self.task_states[task_id]["status"] == "executing":
                 continue
@@ -273,18 +280,59 @@ class DAGInstance:
                 executable.append(task_id)
                 continue
 
-            # Check if all upstream dependencies are completed (not waiting!)
             upstream_tasks = list(self.dag.graph.predecessors(task_id))
-            # All upstream tasks must be completed AND not currently waiting
-            all_upstream_done = all(
-                upstream in self.completed_tasks and
+
+            # All upstream tasks must be resolved (completed or skipped) and
+            # none of them currently waiting.
+            all_upstream_resolved = all(
+                (upstream in self.completed_tasks or upstream in self.skipped_tasks) and
                 self.task_states.get(upstream, {}).get("status") != "waiting"
                 for upstream in upstream_tasks
             )
-            if all_upstream_done:
+            # At least one upstream must have completed (avoid running a task
+            # that only has skipped upstreams — those cascade-skip via propagate_skips).
+            any_upstream_completed = (
+                not upstream_tasks
+                or any(u in self.completed_tasks for u in upstream_tasks)
+            )
+            if all_upstream_resolved and any_upstream_completed:
                 executable.append(task_id)
-        
+
         return executable
+
+    def propagate_skips(self) -> Set[str]:
+        """
+        Cascade skip status: a task whose direct upstreams are ALL skipped
+        (and has at least one upstream) is itself marked skipped.
+
+        Iterates until no more cascades are found so long chains of skipped
+        branches are fully collapsed in one call.
+
+        Returns:
+            Set of task IDs that were newly skipped in this call.
+        """
+        newly_skipped: Set[str] = set()
+        changed = True
+        while changed:
+            changed = False
+            for task_id in self.dag.tasks.keys():
+                if (task_id in self.completed_tasks
+                        or task_id in self.failed_tasks
+                        or task_id in self.skipped_tasks):
+                    continue
+                status = self.task_states.get(task_id, {}).get("status")
+                if status in ("executing", "waiting"):
+                    continue
+                upstream_tasks = list(self.dag.graph.predecessors(task_id))
+                if not upstream_tasks:
+                    continue
+                if all(u in self.skipped_tasks for u in upstream_tasks):
+                    self.skipped_tasks.add(task_id)
+                    self.task_states[task_id]["status"] = "skipped"
+                    self.task_states[task_id]["completed_at"] = datetime.utcnow()
+                    newly_skipped.add(task_id)
+                    changed = True
+        return newly_skipped
     
     def update_task_status(
         self,
@@ -332,20 +380,25 @@ class DAGInstance:
         elif status == "failed":
             self.task_states[task_id]["completed_at"] = datetime.utcnow()
             self.failed_tasks.add(task_id)
-    
+
+        elif status == "skipped":
+            self.task_states[task_id]["completed_at"] = datetime.utcnow()
+            self.skipped_tasks.add(task_id)
+
     def is_completed(self) -> bool:
-        """Check if all tasks are completed"""
-        return len(self.completed_tasks) == len(self.dag.tasks)
+        """Check if all tasks are resolved (completed or skipped)."""
+        return (len(self.completed_tasks) + len(self.skipped_tasks)) == len(self.dag.tasks)
     
     def has_failed(self) -> bool:
         """Check if any task has failed"""
         return len(self.failed_tasks) > 0
     
     def get_progress_percentage(self) -> float:
-        """Get completion percentage"""
+        """Get completion percentage (completed + skipped count as finished)."""
         if not self.dag.tasks:
             return 0.0
-        return (len(self.completed_tasks) / len(self.dag.tasks)) * 100
+        resolved = len(self.completed_tasks) + len(self.skipped_tasks)
+        return (resolved / len(self.dag.tasks)) * 100
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert instance to dictionary"""

--- a/backend/app/workflows/executor.py
+++ b/backend/app/workflows/executor.py
@@ -198,8 +198,9 @@ class DAGExecutor:
             # Restore task states from database
             dag_instance.completed_tasks = set(db_instance.completed_steps or [])
             dag_instance.failed_tasks = set(db_instance.failed_steps or [])
+            dag_instance.skipped_tasks = set(getattr(db_instance, "skipped_steps", None) or [])
             dag_instance.current_task = db_instance.current_step
-            
+
             # Initialize task states for all tasks
             for task_id in dag.tasks.keys():
                 if task_id == db_instance.current_step and task_id not in dag_instance.completed_tasks:
@@ -209,6 +210,8 @@ class DAGExecutor:
                     dag_instance.task_states[task_id] = {"status": "completed"}
                 elif task_id in dag_instance.failed_tasks:
                     dag_instance.task_states[task_id] = {"status": "failed"}
+                elif task_id in dag_instance.skipped_tasks:
+                    dag_instance.task_states[task_id] = {"status": "skipped"}
                 else:
                     dag_instance.task_states[task_id] = {"status": "pending"}
             
@@ -219,6 +222,7 @@ class DAGExecutor:
             # Instance exists in memory, but we need to sync task states with database
             dag_instance.completed_tasks = set(db_instance.completed_steps or [])
             dag_instance.failed_tasks = set(db_instance.failed_steps or [])
+            dag_instance.skipped_tasks = set(getattr(db_instance, "skipped_steps", None) or [])
             dag_instance.current_task = db_instance.current_step
 
             # Update task states for waiting tasks
@@ -403,6 +407,18 @@ class DAGExecutor:
                     print(f"[EXECUTOR] Task failure error: {getattr(task._last_result, 'error', 'No error message')}")
                 dag_instance.update_task_status(task_id, "failed")
                 break  # Stop processing, task failed
+            elif result == TaskStatus.SKIP:
+                # Short-circuit: this task and its skip-only descendants drop out
+                # of the run. Downstream tasks that also have a completed upstream
+                # still execute (convergence), so this implements Airflow-like
+                # trigger semantics for ShortCircuitOperator branching.
+                dag_instance.update_task_status(task_id, "skipped")
+                newly_skipped = dag_instance.propagate_skips()
+                if newly_skipped:
+                    logger.info(
+                        f"Cascaded skip from {task_id} to descendants: {sorted(newly_skipped)}",
+                        extra={"instance_id": instance_id, "source_task": task_id},
+                    )
             elif result == TaskStatus.RETRY:
                 # Handle workflow recovery logic if next_task is specified
                 if hasattr(task, '_last_result') and task._last_result and hasattr(task._last_result, 'next_task') and task._last_result.next_task:
@@ -545,6 +561,7 @@ class DAGExecutor:
         db_instance.current_step = dag_instance.current_task
         db_instance.completed_steps = list(dag_instance.completed_tasks)
         db_instance.failed_steps = list(dag_instance.failed_tasks)
+        db_instance.skipped_steps = list(dag_instance.skipped_tasks)
         db_instance.updated_at = datetime.utcnow()
 
         if new_status:
@@ -568,11 +585,14 @@ class DAGExecutor:
 
         clear_tasks = recovery_data.get("clear_tasks", [])
 
-        # Clear specified tasks from completed_tasks to allow re-execution
+        # Clear specified tasks from completed/skipped to allow re-execution
         for clear_task in clear_tasks:
             if clear_task in dag_instance.completed_tasks:
                 dag_instance.completed_tasks.remove(clear_task)
                 logger.debug(f"Cleared task {clear_task} from completed tasks")
+            if clear_task in dag_instance.skipped_tasks:
+                dag_instance.skipped_tasks.remove(clear_task)
+                logger.debug(f"Cleared task {clear_task} from skipped tasks")
 
             # Reset task state to pending
             if clear_task in dag_instance.task_states:
@@ -601,11 +621,13 @@ class DAGExecutor:
             "error": None
         }
 
-        # Remove next_task from completed and failed tasks
+        # Remove next_task from completed, failed, and skipped tasks
         if next_task_id in dag_instance.completed_tasks:
             dag_instance.completed_tasks.remove(next_task_id)
         if next_task_id in dag_instance.failed_tasks:
             dag_instance.failed_tasks.remove(next_task_id)
+        if next_task_id in dag_instance.skipped_tasks:
+            dag_instance.skipped_tasks.remove(next_task_id)
 
         # Preserve retry context history
         if "retries" not in dag_instance.context:
@@ -644,11 +666,13 @@ class DAGExecutor:
             all_downstream_tasks.add(next_task_id)  # Include next_task itself
 
             for task_to_reset in all_downstream_tasks:
-                # Remove from completed/failed sets
+                # Remove from completed/failed/skipped sets
                 if task_to_reset in dag_instance.completed_tasks:
                     dag_instance.completed_tasks.remove(task_to_reset)
                 if task_to_reset in dag_instance.failed_tasks:
                     dag_instance.failed_tasks.remove(task_to_reset)
+                if task_to_reset in dag_instance.skipped_tasks:
+                    dag_instance.skipped_tasks.remove(task_to_reset)
 
                 # Reset task state
                 dag_instance.task_states[task_to_reset] = {


### PR DESCRIPTION
## Contexto

`ShortCircuitOperator` (en `operators/python.py`) retorna `TaskStatus.SKIP` cuando su callable devuelve False, con la intencion de que el executor salte los descendientes. Pero el executor trataba SKIP como un status sin handler especifico: caia en el branch \`else\` y marcaba la tarea como \"completed\", por lo que sus descendientes se ejecutaban normalmente.

Resultado practico: **ShortCircuitOperator no hacia branching real** — ambas ramas de un grafo con dos `gate` paralelos corrian siempre, lo que obligaba a duplicar workflows enteros para manejar branching (p.ej. un workflow por \"tipo_persona\" en trámites que necesitan ajustar documentos segun el tipo).

## Fix

Implementa semantica de SKIP tipo Airflow:

### Nuevas estructuras en `DAGInstance`
- `skipped_tasks: Set[str]` — IDs de tareas cortocircuitadas o cascada-skipped.
- `update_task_status` acepta `status=\"skipped\"` y lo registra en `skipped_tasks`.
- `propagate_skips()` — cascada: si todas las dependencias directas de una tarea estan skipped, la tarea misma se marca skipped. Itera hasta estabilizarse para colapsar ramas enteras.

### Reglas de `get_executable_tasks`
- Una tarea es elegible si **todas sus dependencias directas estan resueltas** (completed o skipped) **y al menos una completo** (tareas sin upstream completed caen en `propagate_skips`).
- Permite convergencia: una tarea con upstreams `[task_a, task_b]` donde uno completo y el otro skipped **se ejecuta**.

### Completitud
- `is_completed()` ahora es `True` cuando `|completed| + |skipped| == |tasks|`.
- `get_progress_percentage()` cuenta skipped como resuelto.

### Persistencia
- `WorkflowInstance.skipped_steps: List[str]` (campo nuevo, MongoDB schema-less asi que no rompe instances existentes — leen `[]` por default).
- Executor persiste/restaura skipped_tasks junto con completed/failed.

### Manejo en executor
Al recibir `TaskStatus.SKIP`:
\`\`\`python
dag_instance.update_task_status(task_id, \"skipped\")
newly_skipped = dag_instance.propagate_skips()
if newly_skipped:
    logger.info(f\"Cascaded skip from {task_id} to {newly_skipped}\")
\`\`\`

Tambien se corrigio `_execute_retry_workflow_reset` para limpiar `skipped_tasks` al resetear downstream.

## Verificacion

DAG de prueba:
\`\`\`
root -> [gate_a, gate_b]
gate_a -> task_a
gate_b -> task_b
[task_a, task_b] -> converge
\`\`\`

Con `gate_a` returning True (continue) y `gate_b` returning False (skip):

| ciclo | executable | resultado |
|-------|-----------|-----------|
| 1 | root | CONTINUE |
| 2 | gate_a, gate_b | CONTINUE, SKIP (cascada a task_b) |
| 3 | task_a | CONTINUE |
| 4 | converge | CONTINUE |

Estado final:
- completed: `{root, gate_a, task_a, converge}`
- skipped: `{gate_b, task_b}`
- is_completed: `True`

Convergencia funciona: `converge` corre con un upstream completed y otro skipped.

## Test plan

- [x] DAG de prueba manual validado (ver arriba)
- [x] Workflow real en catastro (\`acreditacion_representacion_legal\` unificado) corre end-to-end con ambas ramas (persona_fisica y persona_moral) — emite Entity correcto y marca instance como completed (16 tasks, 10 completed + 6 skipped para PF; 10 completed + 6 skipped para PM)
- [ ] Verificar que workflows preexistentes sin ShortCircuit siguen comportandose igual (no rompe nada — skipped_tasks queda vacio)

## Notas

- No cambia la semantica de tareas sin ShortCircuit: `skipped_tasks` permanece vacio y todo sigue igual.
- No afecta persistencia hacia atras: instances existentes leen `skipped_steps=[]` por default en Mongo.