### PR TITLE
fix(signer): permitir datetimes en el contexto al calcular el hash de firma

### DIFF
--- a/backend/app/workflows/operators/signer_operator.py
+++ b/backend/app/workflows/operators/signer_operator.py
@@ -6,7 +6,7 @@ handles client-side X.509 certificate signing, and stores the signature
 in the context for subsequent operators to use.
 """
 from typing import Dict, Any, List, Optional, Union
-from datetime import datetime
+from datetime import datetime, date
 import json
 import hashlib
 import base64
@@ -15,6 +15,21 @@ from pydantic import BaseModel, Field
 from .base import BaseOperator, TaskResult, TaskStatus
 from ...services.signature.context_signer import ContextSignerService
 from ...models.workflow import WorkflowInstance
+
+
+def _json_default(obj):
+    """JSON default handler para tipos no nativos que llegan en el contexto.
+
+    El contexto persistido en Mongo trae datetimes (BSON) que llegan al
+    operador sin serializar. Sin un handler, json.dumps revienta con
+    "Object of type datetime is not JSON serializable" al calcular el hash
+    de integridad. Convertimos datetimes/dates a ISO 8601 (estable y
+    determinístico para el hash) y caemos a str() para cualquier otro
+    tipo no estándar.
+    """
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    return str(obj)
 
 
 class SignerOperator(BaseOperator):
@@ -142,7 +157,7 @@ class SignerOperator(BaseOperator):
         })
 
         # Create hash of the signable data for integrity
-        data_json = json.dumps(signable_data, sort_keys=True)
+        data_json = json.dumps(signable_data, sort_keys=True, default=_json_default)
         data_hash = hashlib.sha256(data_json.encode()).hexdigest()
         signable_data["data_hash"] = data_hash
 


### PR DESCRIPTION
## Resumen

Bug encontrado al validar el trámite Aviso de Arribo en CONAPESCA. El reviewer aprobaba la solicitud pero al llegar a `sign_document` (paso de firma del documento aprobatorio en `admin_validacion_conapesca`), el operador fallaba con:

\`\`\`
TypeError: Object of type datetime is not JSON serializable
  File "/app/app/workflows/operators/signer_operator.py", line 145, in _prepare_signable_data
  File "/app/app/workflows/operators/signer_operator.py", line 263, in execute_async
\`\`\`

El child workflow quedaba en `status=failed` y el padre también, dejando el trámite del ciudadano atorado sin resolución.

## Root cause

`_prepare_signable_data` calcula un SHA-256 sobre `json.dumps(context, sort_keys=True)` para integridad. Cuando el contexto trae datetimes (BSON nativos de Mongo, o campos `datetime-local` de formularios pasados via `context_mapping` al child workflow), `json.dumps` revienta porque no tiene handler para ese tipo.

El bug es latente desde hace meses — solo se manifiesta cuando un workflow padre inyecta datetimes al child. CONAPESCA Aviso de Arribo lo hace via `context_mapping={"arrival_data": "collect_arrival_data_data", ...}` que contiene `fecha_arribo`/`fecha_salida`.

## Fix

Helper `_json_default` que serializa:
- `datetime` / `date` → ISO 8601 (determinístico, hash reproducible).
- Cualquier otro tipo no estándar → `str()` como fallback.

Aplicado a `json.dumps(signable_data, sort_keys=True, default=_json_default)`.

## Test plan

- [ ] Reproducir el bug pre-fix con un trámite cuyo `context_mapping` incluya datetimes (e.g., CONAPESCA aviso de arribo); confirmar `TASK FAILED: sign_document` en logs.
- [ ] Aplicar el fix y reintentar; confirmar que `sign_document` completa y la firma se almacena.
- [ ] Verificar que el hash es determinístico: dos contextos idénticos producen el mismo hash.
- [ ] Otros workflows que ya usaban el signer (sin datetimes) no deben verse afectados.