### PR TITLE
fix: signer datetime + boto3 credentials vacios

### DIFF
--- a/backend/app/api/v1/entities.py
+++ b/backend/app/api/v1/entities.py
@@ -367,12 +367,15 @@ async def fetch_entity_file(
         s3_key = path_parts[1]
 
         # Initialize S3 client with environment configuration
+        # No pasar aws_access_key_id/aws_secret_access_key explícitamente:
+        # en EC2 esas env vars están definidas pero vacías y boto3 las trata
+        # como credenciales explícitas, saltándose el IAM role del instance
+        # profile y firmando con AKID vacío → AuthorizationHeaderMalformed.
+        # Sin esos params boto3 usa el default credential chain (env → IAM).
         s3_client = boto3.client(
             's3',
             region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
             endpoint_url=os.getenv("S3_ENDPOINT_URL"),
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY")
         )
 
         # Download file from S3

--- a/backend/app/services/file_conversion_service.py
+++ b/backend/app/services/file_conversion_service.py
@@ -361,13 +361,16 @@ class FileConversionService:
                 bucket_name = path_parts[0]
                 s3_key = path_parts[1] if len(path_parts) > 1 else ''
 
-            # Initialize S3 client with environment configuration
+            # Initialize S3 client. No pasar aws_access_key_id/aws_secret_access_key
+            # explícitamente: en EC2 esas env vars están definidas pero vacías y
+            # boto3 las trata como credenciales explícitas, saltándose el IAM role
+            # del instance profile y firmando con AKID vacío
+            # → AuthorizationHeaderMalformed. Sin esos params boto3 usa el default
+            # credential chain (env → IAM).
             s3_client = boto3.client(
                 's3',
                 region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
                 endpoint_url=os.getenv("S3_ENDPOINT_URL"),  # For MinIO
-                aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-                aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY")
             )
 
             try:

--- a/backend/app/workflows/operators/ai_extraction_operator.py
+++ b/backend/app/workflows/operators/ai_extraction_operator.py
@@ -371,12 +371,15 @@ Please extract the information and return only the JSON result, no additional te
                 aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
                 endpoint_url = os.getenv("S3_ENDPOINT_URL")
 
+                # No pasar aws_access_key_id/aws_secret_access_key explícitamente.
+                # En EC2 esas env vars están definidas pero vacías y boto3 las trata
+                # como credenciales explícitas, saltándose el IAM role del instance
+                # profile y firmando con AKID vacío → AuthorizationHeaderMalformed.
+                # Sin esos params boto3 usa el default credential chain (env → IAM).
                 s3_client = boto3.client(
                     's3',
                     region_name=aws_region,
                     endpoint_url=endpoint_url,
-                    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-                    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY")
                 )
 
                 response = s3_client.get_object(Bucket=bucket, Key=s3_key)


### PR DESCRIPTION
## Summary

Dos fixes acumulados en este branch que desbloquean producción:

### 1. `fix(signer): permitir datetimes en el contexto al calcular el hash` (`14f4391`)

`_prepare_signable_data` calculaba SHA256 sobre `json.dumps(context)` sin handler de tipos, lo que reventaba con `Object of type datetime is not JSON serializable` cuando el contexto traía datetimes (BSON de Mongo o campos `datetime-local` de formularios pasados como `context_mapping` a un child workflow).

### 2. `fix(s3): no pasar aws_access_key_id/secret vacios al boto3.client` (`0dfb643`)

En EC2 los containers tienen `AWS_ACCESS_KEY_ID` y `AWS_SECRET_ACCESS_KEY` definidas como string vacío (la instancia usa IAM role del instance profile, no env vars). Cuando `boto3.client` recibe esas vars vacías explícitamente, las trata como credenciales del usuario y no consulta el default credential chain. El request se firma con AKID vacío y S3 responde `AuthorizationHeaderMalformed`.

Tres call-sites afectados, mismo patrón, mismo fix:
- `backend/app/services/file_conversion_service.py`
- `backend/app/workflows/operators/ai_extraction_operator.py`
- `backend/app/api/v1/entities.py`

## Test plan

- [x] Backend levanta sin errores tras restart
- [x] Descargar PDF de 89 KB desde MinIO con el código parchado funciona (probado E2E local con `FileConversionService._download_file_from_url`)
- [ ] Tras merge + deploy, verificar en EC2 que no aparece `AuthorizationHeaderMalformed` en las descargas S3