### PR TITLE
fix(files): endpoint /download con bucket y creds correctos

### DIFF
--- a/backend/app/api/endpoints/files.py
+++ b/backend/app/api/endpoints/files.py
@@ -4,13 +4,14 @@ File Download Endpoints
 Handles downloading files from S3/MinIO storage using s3_key paths.
 """
 
-import os
 import io
+import os
 import mimetypes
-from typing import Any
+import asyncio
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import StreamingResponse
-from ...services.file_conversion_service import FileConversionService
+from ...services import s3_storage
 from ...core.logging_config import get_workflow_logger
 
 logger = get_workflow_logger(__name__)
@@ -22,55 +23,49 @@ async def download_file(s3_key: str):
     """
     Download a file from S3/MinIO using its s3_key path.
 
-    Args:
-        s3_key: The S3 key path for the file (e.g., "catastro/documents/...")
-
-    Returns:
-        StreamingResponse with the file content
+    El bucket sale de la env `S3_BUCKET_NAME` (vía `s3_storage.default_bucket`)
+    y el cliente boto3 cae al default credential chain (env vars en local con
+    MinIO, IAM role del instance profile en EC2). Si el objeto no existe se
+    devuelve 404 explícito; cualquier otro error es 500 — antes este endpoint
+    enmascaraba toda excepción como 404 y ocultaba bugs como un endpoint
+    hardcoded a http://minio:9000 o credenciales mal configuradas.
     """
+    bucket = s3_storage.default_bucket()
+    client = s3_storage.get_s3_client()
+
+    logger.info(f"Downloading s3://{bucket}/{s3_key}")
+
     try:
-        # Initialize file conversion service (has S3 download functionality)
-        file_service = FileConversionService()
-
-        # Construct S3 URL from s3_key
-        # Get S3 config from environment
-        s3_endpoint = os.getenv("S3_ENDPOINT", "http://minio:9000")
-        s3_bucket = os.getenv("S3_BUCKET", "munistream-uploads")
-
-        # Build the S3 URL
-        s3_url = f"{s3_endpoint}/{s3_bucket}/{s3_key}"
-
-        logger.info(f"Downloading file from S3: {s3_url}")
-
-        # Download file from S3
-        file_bytes, filename = await file_service._download_from_s3(s3_url, None)
-
-        # Determine content type
-        content_type, _ = mimetypes.guess_type(filename or s3_key)
-        if not content_type:
-            content_type = "application/octet-stream"
-
-        # Extract just the filename from the s3_key if no filename provided
-        if not filename:
-            filename = os.path.basename(s3_key)
-
-        # Create streaming response
-        file_like = io.BytesIO(file_bytes)
-
-        logger.info(f"Serving file: {filename} ({len(file_bytes)} bytes, {content_type})")
-
-        return StreamingResponse(
-            io.BytesIO(file_bytes),
-            media_type=content_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{filename}"',
-                "Content-Length": str(len(file_bytes))
-            }
+        response = await asyncio.to_thread(
+            client.get_object, Bucket=bucket, Key=s3_key
         )
-
-    except Exception as e:
-        logger.error(f"Error downloading file {s3_key}: {str(e)}")
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            logger.warning(f"S3 object missing for {bucket}/{s3_key}: {code}")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"File not found: {s3_key}",
+            )
+        logger.error(f"S3 ClientError for {bucket}/{s3_key}: {e}")
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"File not found: {s3_key}"
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"S3 error: {code or 'unknown'}",
         )
+
+    file_bytes = await asyncio.to_thread(response["Body"].read)
+
+    filename = os.path.basename(s3_key) or "downloaded_file"
+    content_type, _ = mimetypes.guess_type(filename)
+    content_type = content_type or response.get("ContentType") or "application/octet-stream"
+
+    logger.info(f"Serving {filename} ({len(file_bytes)} bytes, {content_type})")
+
+    return StreamingResponse(
+        io.BytesIO(file_bytes),
+        media_type=content_type,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(file_bytes)),
+        },
+    )


### PR DESCRIPTION
## Summary

`/api/v1/files/download/{s3_key:path}` devolvía 404 en producción al pedir archivos válidos. Dos causas:

1. **Env vars equivocadas**: usaba `S3_ENDPOINT` (default `http://minio:9000` — URL local que no existe en EC2) y `S3_BUCKET` (la var real es `S3_BUCKET_NAME`). El endpoint construía URLs inválidas y `_download_from_s3` fallaba.

2. **`except Exception` enmascaraba todo como 404**, ocultando el bug.

Reescrito para usar `s3_storage.get_s3_client()` + `default_bucket()` (mismo cliente que el resto del backend; el default credential chain cae al IAM role en EC2). Errores diferenciados:
- `NoSuchKey`/`NoSuchBucket` → 404 explícito
- Otro `ClientError` → 502 con código S3 visible

## Test plan

- [x] Local con MinIO: descarga PDF de 89 KB (200, content-disposition correcto).
- [x] Local con MinIO: key inexistente → 404 explícito + log `S3 object missing ... NoSuchKey`.
- [ ] Tras deploy en EC2: descarga real del admin (URL del reporte del usuario, `tramite_01_074/rfc/.../CONAPESCA_42793266.docx`).