### PR TITLE
feat: subida de archivos en captura, documentos opcionales y EntityUpdateOperator

### DIFF
--- a/backend/app/workflows/operators/__init__.py
+++ b/backend/app/workflows/operators/__init__.py
@@ -12,6 +12,7 @@ from .airflow_operator import AirflowOperator
 from .s3_upload import S3UploadOperator
 from .entity_operators import (
     EntityCreationOperator,
+    EntityUpdateOperator,
     EntityValidationOperator,
     EntityRequirementOperator,
     EntityRelationshipOperator,
@@ -56,6 +57,7 @@ __all__ = [
 
     # Entity operators
     "EntityCreationOperator",
+    "EntityUpdateOperator",
     "EntityValidationOperator",
     "EntityRequirementOperator",
     "EntityRelationshipOperator",

--- a/backend/app/workflows/operators/entity_operators.py
+++ b/backend/app/workflows/operators/entity_operators.py
@@ -405,6 +405,124 @@ class EntityCreationOperator(BaseOperator):
         return resolved_template
 
 
+class EntityUpdateOperator(BaseOperator):
+    """Operator que actualiza una entidad existente.
+
+    Útil para trámites que modifican una entidad ya registrada (p.ej. sustituir
+    al titular de una concesión): se toma el id de la entidad de un campo de
+    contexto (típicamente la selección de un EntityPickerOperator) y se aplican
+    los cambios indicados en `data_mapping` (con soporte de paths punteados) y
+    `static_data` sobre el campo `data` de la entidad (merge).
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        entity_id_source: str,
+        data_mapping: Optional[Dict[str, str]] = None,
+        static_data: Optional[Dict[str, Any]] = None,
+        preserve_as: Optional[Dict[str, str]] = None,
+        owner_scoped: bool = False,
+        **kwargs
+    ):
+        """
+        Args:
+            entity_id_source: Clave de contexto con el id de la entidad a actualizar.
+                Si el valor es una lista (p.ej. `concesion_ids`), se usa el primero.
+            data_mapping: Mapa {ruta_en_contexto: campo_en_data} a actualizar.
+            static_data: Campos fijos a fijar en `data`.
+            preserve_as: Mapa {campo_actual_en_data: campo_destino} que copia el
+                valor ACTUAL de la entidad (antes de sobrescribir) a otro campo,
+                p.ej. {"customer_name": "titular_anterior"} para conservar el
+                titular previo al sustituirlo.
+            owner_scoped: Si es True, sólo actualiza si la entidad pertenece al
+                usuario del contexto; por defecto False (flujo validado por admin).
+        """
+        super().__init__(task_id, **kwargs)
+        self.entity_id_source = entity_id_source
+        self.data_mapping = data_mapping or {}
+        self.static_data = static_data or {}
+        self.preserve_as = preserve_as or {}
+        self.owner_scoped = owner_scoped
+
+    def _resolve_entity_id(self, context: Dict[str, Any]) -> Optional[str]:
+        value = _resolve_context_path(context, self.entity_id_source)
+        if isinstance(value, list):
+            return value[0] if value else None
+        return value
+
+    def execute(self, context: Dict[str, Any]) -> TaskResult:
+        try:
+            entity_id = self._resolve_entity_id(context)
+            if not entity_id:
+                return TaskResult(
+                    status=TaskStatus.FAILED,
+                    error=f"No se encontró id de entidad en '{self.entity_id_source}'"
+                )
+
+            updates: Dict[str, Any] = dict(self.static_data)
+            for context_key, data_field in self.data_mapping.items():
+                value = _resolve_context_path(context, context_key)
+                if value is not None:
+                    updates[data_field] = value
+
+            owner_user_id = None
+            if self.owner_scoped:
+                owner_user_id = context.get("user_id") or context.get("customer_id")
+
+            self._update_params = {
+                "entity_id": entity_id,
+                "updates": {"data": updates},
+                "owner_user_id": owner_user_id,
+            }
+            return TaskResult(status=TaskStatus.PENDING_ASYNC, data={})
+        except Exception as e:
+            return TaskResult(status=TaskStatus.FAILED, error=f"Failed to prepare entity update: {str(e)}")
+
+    async def execute_async(self, context: Dict[str, Any]) -> TaskResult:
+        result = self.execute(context)
+        if not hasattr(self, "_update_params") or not self._update_params:
+            return result
+
+        params = self._update_params
+        await self.log_info(
+            f"Actualizando entidad {params['entity_id']}",
+            details={"fields": list(params['updates'].get('data', {}).keys())}
+        )
+        try:
+            # Conservar valores actuales antes de sobrescribir (p.ej. titular anterior)
+            if self.preserve_as:
+                current = await EntityService.get_entity(params["entity_id"], params["owner_user_id"])
+                if current is not None:
+                    for src_field, target_field in self.preserve_as.items():
+                        old_value = (current.data or {}).get(src_field)
+                        if old_value is not None:
+                            params["updates"]["data"][target_field] = old_value
+
+            entity = await EntityService.update_entity(
+                params["entity_id"], params["updates"], params["owner_user_id"]
+            )
+            if entity is None:
+                return TaskResult(
+                    status=TaskStatus.FAILED,
+                    error=f"No se pudo actualizar: entidad {params['entity_id']} no encontrada"
+                )
+            await self.log_info(
+                f"Entidad {entity.entity_id} actualizada",
+                details={"entity_id": entity.entity_id, "data": entity.data}
+            )
+            output_data = {
+                f"{self.task_id}_entity_id": entity.entity_id,
+                f"{self.task_id}_entity_type": entity.entity_type,
+                f"updated_entity_{entity.entity_type}": entity.entity_id,
+            }
+            self.state.output_data = output_data
+            return TaskResult(status=TaskStatus.CONTINUE, data=output_data)
+        except Exception as e:
+            await self.log_error(f"Falló la actualización de la entidad {params['entity_id']}", error=e)
+            return TaskResult(status=TaskStatus.FAILED, error=str(e))
+
+
 class EntityValidationOperator(BaseOperator):
     """
     Simple operator that validates an entity exists and meets basic criteria.

--- a/backend/app/workflows/operators/id_capture_operator.py
+++ b/backend/app/workflows/operators/id_capture_operator.py
@@ -62,6 +62,7 @@ class IDCaptureOperator(ImageCaptureOperator):
         detect_text: bool = True,
         detect_codes: bool = True,
         validation_config: Optional[Dict] = None,
+        allow_file_upload: bool = False,
         **kwargs
     ):
         """
@@ -80,6 +81,8 @@ class IDCaptureOperator(ImageCaptureOperator):
             detect_text: Whether to detect text presence
             detect_codes: Whether to detect and decode QR/barcodes
             validation_config: Additional validation parameters
+            allow_file_upload: Permitir subir archivos de imagen (frente/reverso)
+                además de la cámara en vivo (omite validaciones de captura en vivo)
         """
         # Default instructions
         default_instructions = {
@@ -96,13 +99,20 @@ class IDCaptureOperator(ImageCaptureOperator):
         # Simple form config for waiting_for="id_capture" pattern
         form_config = {
             "title": "Captura de Documento de Identidad",
-            "description": "Captura ambos lados del documento usando la cámara de tu dispositivo.",
+            "description": (
+                "Sube los archivos o captura ambos lados del documento con la cámara."
+                if allow_file_upload else
+                "Captura ambos lados del documento usando la cámara de tu dispositivo."
+            ),
             "capture_type": "id_document",
+            "allow_file_upload": allow_file_upload,
             "instructions": [
                 "Asegúrate de tener buena iluminación",
                 "Mantén el documento plano y centrado",
                 "Verifica que todo el texto sea legible",
-                "Ambas capturas (frente y reverso) son obligatorias"
+                ("Puedes subir un archivo (INE, pasaporte, etc.) o usar la cámara"
+                 if allow_file_upload else
+                 "Ambas capturas (frente y reverso) son obligatorias")
             ],
             "camera_settings": {
                 "facingMode": "environment",  # Back camera for documents
@@ -116,8 +126,9 @@ class IDCaptureOperator(ImageCaptureOperator):
                 "auto_capture": False,
                 "preview_before_submit": True,
                 "allow_retake": allow_retake,
+                "allow_file_upload": allow_file_upload,
                 "max_file_size": 10 * 1024 * 1024,  # 10MB per image
-                "require_permissions": ["camera"],
+                "require_permissions": [] if allow_file_upload else ["camera"],
                 "validation_feedback": True,
                 "detect_edges": True,  # Document edge detection
                 "min_document_coverage": 0.7  # 70% of frame should be document
@@ -126,6 +137,7 @@ class IDCaptureOperator(ImageCaptureOperator):
 
         kwargs['form_config'] = form_config
         kwargs['required_fields'] = ["document_front", "document_back"]
+        kwargs['allow_file_upload'] = allow_file_upload
 
         # Initialize with base class (handles common parameters)
         super().__init__(task_id, **kwargs)

--- a/backend/app/workflows/operators/image_capture_base.py
+++ b/backend/app/workflows/operators/image_capture_base.py
@@ -41,6 +41,7 @@ class ImageCaptureOperator(BaseOperator):
         timeout_minutes: int = 10,
         max_timestamp_age_seconds: int = 60,
         allow_retake: bool = True,
+        allow_file_upload: bool = False,
         **kwargs
     ):
         super().__init__(task_id, **kwargs)
@@ -49,6 +50,11 @@ class ImageCaptureOperator(BaseOperator):
         self.timeout_minutes = timeout_minutes
         self.max_timestamp_age_seconds = max_timestamp_age_seconds
         self.allow_retake = allow_retake
+        # Cuando es True, la imagen puede provenir de un archivo subido (no solo
+        # cámara en vivo): se omiten las validaciones de captura en vivo
+        # (timestamp, browser fingerprint, getUserMedia) y se conserva la
+        # evaluación de calidad de imagen.
+        self.allow_file_upload = allow_file_upload
 
     def extract_image_from_formdata(self, image_data_raw: Any) -> tuple[Union[str, bytes], Dict[str, Any]]:
         """
@@ -111,23 +117,32 @@ class ImageCaptureOperator(BaseOperator):
             if image_bytes is None:
                 return {"valid": False, "errors": ["Invalid image data format"], "reason": "invalid_format"}
 
-            # 1. Timestamp validation
-            timestamp_valid = self.validate_timestamp(metadata)
-            if not timestamp_valid['valid']:
-                errors.extend(timestamp_valid['errors'])
-            validation_details['timestamp_verified'] = timestamp_valid['valid']
+            if self.allow_file_upload:
+                # Archivo subido: no aplican las validaciones de captura en vivo
+                # (timestamp / browser fingerprint / getUserMedia). Se marcan como
+                # no aplicables y solo se evalúa la calidad de la imagen.
+                validation_details['timestamp_verified'] = None
+                validation_details['browser_fingerprint_verified'] = None
+                validation_details['live_capture_verified'] = None
+                validation_details['source'] = 'file_upload'
+            else:
+                # 1. Timestamp validation
+                timestamp_valid = self.validate_timestamp(metadata)
+                if not timestamp_valid['valid']:
+                    errors.extend(timestamp_valid['errors'])
+                validation_details['timestamp_verified'] = timestamp_valid['valid']
 
-            # 2. Browser fingerprint validation
-            fingerprint_valid = self.validate_browser_fingerprint(metadata)
-            if not fingerprint_valid['valid']:
-                errors.extend(fingerprint_valid['errors'])
-            validation_details['browser_fingerprint_verified'] = fingerprint_valid['valid']
+                # 2. Browser fingerprint validation
+                fingerprint_valid = self.validate_browser_fingerprint(metadata)
+                if not fingerprint_valid['valid']:
+                    errors.extend(fingerprint_valid['errors'])
+                validation_details['browser_fingerprint_verified'] = fingerprint_valid['valid']
 
-            # 3. Live capture validation
-            live_capture_valid = self.validate_live_capture(image_bytes, metadata)
-            if not live_capture_valid['valid']:
-                errors.extend(live_capture_valid['errors'])
-            validation_details['live_capture_verified'] = live_capture_valid['valid']
+                # 3. Live capture validation
+                live_capture_valid = self.validate_live_capture(image_bytes, metadata)
+                if not live_capture_valid['valid']:
+                    errors.extend(live_capture_valid['errors'])
+                validation_details['live_capture_verified'] = live_capture_valid['valid']
 
             # 4. Image quality assessment
             quality_result = self.assess_image_quality(image_bytes)

--- a/backend/app/workflows/operators/s3_upload.py
+++ b/backend/app/workflows/operators/s3_upload.py
@@ -62,6 +62,7 @@ class S3UploadOperator(BaseOperator):
         acl: Optional[str] = None,
         max_file_size: int = 100 * 1024 * 1024,  # 100MB default
         allowed_extensions: Optional[List[str]] = None,
+        skip_if_missing: bool = False,
         **kwargs
     ):
         """
@@ -80,11 +81,15 @@ class S3UploadOperator(BaseOperator):
             acl: S3 ACL (private, public-read, public-read-write, etc.)
             max_file_size: Maximum allowed file size in bytes
             allowed_extensions: List of allowed file extensions
+            skip_if_missing: Si es True y no hay archivo en el contexto, el paso
+                continúa sin fallar (para documentos opcionales). Por defecto False
+                mantiene el comportamiento estricto (falla si falta el archivo).
         """
         super().__init__(task_id, **kwargs)
         self.bucket_name = bucket_name or os.getenv("S3_BUCKET_NAME", "munistream-uploads")
         self.s3_prefix = s3_prefix
         self.file_source = file_source
+        self.skip_if_missing = skip_if_missing
         self.make_public = make_public
         self.metadata_tags = metadata_tags or {}
         self.content_type = content_type
@@ -649,6 +654,24 @@ class S3UploadOperator(BaseOperator):
                     files_data = [files_data]
 
             if not files_data:
+                if self.skip_if_missing:
+                    # Documento opcional ausente: continuar sin fallar.
+                    print(f"⏭️ S3UploadOperator: sin archivo en '{self.file_source}' (opcional), se omite la carga")
+                    return TaskResult(
+                        status=TaskStatus.CONTINUE,
+                        data={
+                            f"{self.task_id}_result": {
+                                "uploaded_files": [],
+                                "failed_files": [],
+                                "total_files": 0,
+                                "successful_count": 0,
+                                "failed_count": 0,
+                                "skipped": True,
+                                "bucket": self.bucket_name,
+                                "timestamp": datetime.utcnow().isoformat()
+                            }
+                        }
+                    )
                 error_msg = f"No files found in context key '{self.file_source}'. Expected files for upload but none were provided."
                 print(f"❌ S3UploadOperator: {error_msg}")
                 return TaskResult(

--- a/backend/app/workflows/operators/selfie_operator.py
+++ b/backend/app/workflows/operators/selfie_operator.py
@@ -50,6 +50,7 @@ class SelfieOperator(ImageCaptureOperator):
         purpose: str = "identity_verification",
         require_face_detection: bool = True,
         require_liveness: bool = False,
+        allow_file_upload: bool = False,
         **kwargs
     ):
         """
@@ -61,12 +62,19 @@ class SelfieOperator(ImageCaptureOperator):
             purpose: Purpose of selfie capture for audit trail
             require_face_detection: Whether face detection is mandatory
             require_liveness: Whether liveness detection is required
+            allow_file_upload: Permitir subir un archivo de imagen además de la
+                cámara en vivo (omite las validaciones de captura en vivo)
         """
         # Simple form config for waiting_for="selfie" pattern
         form_config = {
             "title": "Verificación de Identidad - Selfie",
-            "description": "Toma una selfie usando la cámara de tu dispositivo para verificar tu identidad.",
+            "description": (
+                "Sube una foto o toma una selfie para verificar tu identidad."
+                if allow_file_upload else
+                "Toma una selfie usando la cámara de tu dispositivo para verificar tu identidad."
+            ),
             "capture_type": "selfie",
+            "allow_file_upload": allow_file_upload,
             "camera_settings": {
                 "facingMode": "user",  # Front camera for selfie
                 "width": {"min": 640, "ideal": 1280, "max": 1920},
@@ -79,20 +87,24 @@ class SelfieOperator(ImageCaptureOperator):
                 "auto_capture": False,  # Manual capture only
                 "preview_before_submit": True,
                 "allow_retake": True,
+                "allow_file_upload": allow_file_upload,
                 "max_file_size": 5 * 1024 * 1024,  # 5MB
-                "require_permissions": ["camera"],
+                "require_permissions": [] if allow_file_upload else ["camera"],
                 "validation_feedback": True  # Show validation results
             },
             "instructions": [
                 "Asegúrate de tener buena iluminación",
                 "Mantén tu rostro centrado en el marco",
                 "Quítate lentes de sol o elementos que oculten tu cara",
-                "La foto se tomará en tiempo real con la cámara"
+                ("Puedes subir un archivo de imagen o usar la cámara"
+                 if allow_file_upload else
+                 "La foto se tomará en tiempo real con la cámara")
             ]
         }
 
         kwargs['form_config'] = form_config
         kwargs['required_fields'] = ["selfie_image"]
+        kwargs['allow_file_upload'] = allow_file_upload
 
         # Initialize with base class (handles common parameters)
         super().__init__(task_id, **kwargs)


### PR DESCRIPTION
Mejoras del motor para soportar correcciones de CONAPESCA (spreadsheet junio 2026):

- **allow_file_upload** en SelfieOperator/IDCaptureOperator: permite cargar un archivo de imagen en lugar de forzar cámara en vivo. Cuando está activo, `validate_capture` omite las validaciones de captura en vivo (timestamp, browser fingerprint, getUserMedia) y conserva la evaluación de calidad. Por defecto `False` (sin cambios para flujos existentes).
- **skip_if_missing** en S3UploadOperator: continúa sin fallar cuando un documento opcional no se proporciona, en lugar de devolver FAILED.
- **EntityUpdateOperator** (nuevo): actualiza una entidad existente (id tomado de la selección de un EntityPicker) aplicando `data_mapping`/`static_data` sobre `data` (merge). Soporta `preserve_as` para conservar valores previos antes de sobrescribir (p.ej. titular anterior).

Verificado con pruebas E2E de punta a punta (ciudadano + reviewer) sobre los trámites de CONAPESCA.