### PR TITLE
feat(auth): endpoint público de identity providers

### DIFF
--- a/backend/app/api/endpoints/public.py
+++ b/backend/app/api/endpoints/public.py
@@ -989,7 +989,9 @@ def _extract_entity_requirements(dag: DAG) -> List[Dict[str, Any]]:
 async def _get_workflow_data(workflow: WorkflowDefinition, dag: Optional[DAG], locale: str) -> Dict[str, Any]:
     """Extract all workflow data from definition and DAG."""
     steps = []
-    
+    branches: list = []
+    step_flow: list = []
+
     # Prefer DAG data over database data
     if dag:
         # Get workflow info from DAG (it has the most up-to-date data)
@@ -998,7 +1000,67 @@ async def _get_workflow_data(workflow: WorkflowDefinition, dag: Optional[DAG], l
         category = dag.category if hasattr(dag, 'category') else (workflow.category or "general")
         tags = dag.tags if dag.tags else (workflow.tags or [])
         metadata = dag.metadata if hasattr(dag, 'metadata') and dag.metadata else (workflow.metadata or {})
-        
+
+        # Branch detection (robust for multiple / sequential forks). Branches are
+        # ShortCircuitOperator gates; the citizen has not chosen a route yet on
+        # this preview, so each step is classified to the route of the NEAREST
+        # gate that DOMINATES it (every path to the step passes through that
+        # gate). Steps dominated by no gate are common to all routes. Dominators
+        # handle nesting/sequential forks correctly, unlike a descendants test.
+        from ...workflows.operators.python import ShortCircuitOperator
+        import networkx as nx
+        G = dag.graph
+        gate_label: Dict[str, str] = {}    # gate task_id -> route label
+        for tid, t in dag.tasks.items():
+            if isinstance(t, ShortCircuitOperator):
+                label = (getattr(t, 'name', '') or '').replace('Rama ', '').strip()
+                gate_label[tid] = label or tid
+        gate_ids = set(gate_label.keys())
+
+        step_branch: Dict[str, str] = {}   # task_id -> route label
+        step_fork: Dict[str, str] = {}     # task_id -> fork id (decision point)
+        branches: list = []
+        if gate_ids:
+            try:
+                roots = [n for n in G.nodes if G.in_degree(n) == 0]
+                if len(roots) == 1:
+                    idom = nx.immediate_dominators(G, roots[0])
+                else:
+                    GG = G.copy()
+                    GG.add_node("__start__")
+                    for r in roots:
+                        GG.add_edge("__start__", r)
+                    idom = nx.immediate_dominators(GG, "__start__")
+            except Exception:
+                idom = {}
+
+            gate_fork = {g: idom.get(g, g) for g in gate_ids}  # decision point per gate
+
+            def _nearest_gate(node):
+                cur = idom.get(node)
+                seen = set()
+                while cur is not None and cur not in seen:
+                    seen.add(cur)
+                    if cur in gate_ids:
+                        return cur
+                    nxt = idom.get(cur)
+                    if nxt == cur:
+                        break
+                    cur = nxt
+                return None
+
+            for tid in dag.tasks.keys():
+                if tid in gate_ids:
+                    continue
+                g = _nearest_gate(tid)
+                if g is not None:
+                    step_branch[tid] = gate_label[g]
+                    step_fork[tid] = gate_fork.get(g, g)
+
+            branches = list(dict.fromkeys(
+                gate_label[t] for t in dag.tasks.keys() if t in gate_ids
+            ))
+
         # Get steps from DAG
         for task_id, task in dag.tasks.items():
             step_data = {
@@ -1008,6 +1070,10 @@ async def _get_workflow_data(workflow: WorkflowDefinition, dag: Optional[DAG], l
             }
             if task.group:
                 step_data["group"] = task.group
+
+            # Mark steps exclusive to a single branch (route)
+            if task_id in step_branch:
+                step_data["branch"] = step_branch[task_id]
 
             # Add description if available
             if hasattr(task, 'description'):
@@ -1028,6 +1094,52 @@ async def _get_workflow_data(workflow: WorkflowDefinition, dag: Optional[DAG], l
                 step_data["requirements"] = task.requirements
 
             steps.append(step_data)
+
+        # Build step_flow: ordered segments the portal renders as an
+        # interactive stepper — runs of common steps, and "fork" zones whose
+        # routes the citizen can expand. Branch steps of a fork are contiguous
+        # in topological order between the decision point and the convergence.
+        def _slim(tid):
+            t = dag.tasks[tid]
+            s = {"id": tid, "name": t.name}
+            if t.group:
+                s["group"] = t.group
+            return s
+
+        seg = None    # current common-steps segment
+        fork = None   # current fork: {"id", "routes": {label: [..]}, "order": [labels]}
+        for tid in dag.tasks.keys():
+            if tid in gate_ids:
+                continue
+            lbl = step_branch.get(tid)
+            if lbl:
+                if seg is not None:
+                    step_flow.append(seg)
+                    seg = None
+                f = step_fork.get(tid)
+                if fork is not None and fork["id"] != f:
+                    step_flow.append({"type": "fork", "routes": [
+                        {"label": l, "steps": fork["routes"][l]} for l in fork["order"]]})
+                    fork = None
+                if fork is None:
+                    fork = {"id": f, "routes": {}, "order": []}
+                if lbl not in fork["routes"]:
+                    fork["routes"][lbl] = []
+                    fork["order"].append(lbl)
+                fork["routes"][lbl].append(_slim(tid))
+            else:
+                if fork is not None:
+                    step_flow.append({"type": "fork", "routes": [
+                        {"label": l, "steps": fork["routes"][l]} for l in fork["order"]]})
+                    fork = None
+                if seg is None:
+                    seg = {"type": "steps", "steps": []}
+                seg["steps"].append(_slim(tid))
+        if seg is not None:
+            step_flow.append(seg)
+        if fork is not None:
+            step_flow.append({"type": "fork", "routes": [
+                {"label": l, "steps": fork["routes"][l]} for l in fork["order"]]})
     else:
         # Fall back to database data if no DAG
         name = workflow.name
@@ -1078,6 +1190,8 @@ async def _get_workflow_data(workflow: WorkflowDefinition, dag: Optional[DAG], l
         "estimatedDuration": metadata.get("estimatedTime") or metadata.get("estimated_duration") or _calculate_duration(len(steps)),
         "cost": metadata.get("cost"),
         "steps": steps,
+        "branches": branches,
+        "step_flow": step_flow,
         "requirements": metadata.get("requirements", []) or _get_workflow_requirements(workflow, locale),
         "entity_requirements": _extract_entity_requirements(dag) if dag else [],
         "available": metadata.get("available", True) if "available" in metadata else workflow.status == "active",

--- a/backend/app/api/endpoints/public.py
+++ b/backend/app/api/endpoints/public.py
@@ -27,6 +27,18 @@ router = APIRouter()
 router.include_router(auth_router)
 
 
+@router.get("/identity-providers")
+async def list_identity_providers() -> Dict[str, Any]:
+    """List enabled identity providers for the citizen realm.
+
+    Public endpoint: lets the citizen portal render login buttons (e.g. LlaveMX)
+    dynamically. Returns an empty list if none are configured.
+    """
+    from ...services.keycloak_sync import keycloak_sync_service
+    providers = await keycloak_sync_service.get_identity_providers()
+    return {"identity_providers": providers}
+
+
 @router.post("/instances/{instance_id}/rewind")
 async def rewind_instance(
     instance_id: str,

--- a/backend/app/api/endpoints/public_auth.py
+++ b/backend/app/api/endpoints/public_auth.py
@@ -373,18 +373,60 @@ async def track_instance(
             if "current_step_id" not in input_form:
                 input_form["current_step_id"] = waiting_tasks[0]
 
-    # Calculate progress
-    total_steps = len(dag_instance.dag.tasks) if dag_instance and dag_instance.dag else 0
-    completed_steps = 0
+    # Build the citizen-facing step list. Branched workflows (e.g. RNPA
+    # persona física / moral) use ShortCircuitOperator gates whose non-taken
+    # branch is marked "skipped" by propagate_skips(). We hide both the
+    # internal gates and the skipped branch so the citizen only sees their own
+    # route, and we derive the route label from the gate that actually ran.
+    from ...workflows.operators.python import ShortCircuitOperator
+
     step_progress = []
+    route_label = None
+
+    # Identify the non-taken branch so the citizen only sees their own route.
+    # A ShortCircuitOperator gate that did NOT complete means its branch was
+    # not taken. Reconstruction from the DB leaves that branch's steps as
+    # "pending" (they were never executed and have no StepExecution record), so
+    # there is no "skipped" status to rely on — we cascade from the un-taken
+    # gates instead. Convergence steps survive because they also have a
+    # completed (taken-branch) upstream, so not ALL their upstreams are dead.
+    dead_branch = set()
+    if dag_instance:
+        def _status_of(tid):
+            return dag_instance.task_states.get(tid, {}).get("status", "pending")
+
+        for tid, task in dag_instance.dag.tasks.items():
+            if isinstance(task, ShortCircuitOperator) and _status_of(tid) != "completed":
+                dead_branch.add(tid)
+
+        changed = True
+        while changed:
+            changed = False
+            for tid in dag_instance.dag.tasks.keys():
+                if tid in dead_branch or _status_of(tid) == "completed":
+                    continue
+                ups = list(dag_instance.dag.graph.predecessors(tid))
+                if ups and all(u in dead_branch for u in ups):
+                    dead_branch.add(tid)
+                    changed = True
 
     if dag_instance:
         for task_id, state in dag_instance.task_states.items():
             status_val = state.get("status", "pending")
-            if status_val == "completed":
-                completed_steps += 1
-
             task_obj = dag_instance.dag.tasks.get(task_id)
+
+            # Branch gates are internal control steps, not citizen steps. The
+            # gate that completed (rather than skipped) reveals the route taken.
+            if isinstance(task_obj, ShortCircuitOperator):
+                if status_val == "completed" and route_label is None:
+                    gate_name = getattr(task_obj, "name", None) or ""
+                    route_label = gate_name.replace("Rama ", "").strip() or None
+                continue
+
+            # Hide the non-taken branch (skipped, or pending-but-unreachable).
+            if status_val == "skipped" or task_id in dead_branch:
+                continue
+
             task_name = getattr(task_obj, 'name', None)
             if not task_name:
                 i18n_key = f"steps.{task_id}"
@@ -404,7 +446,35 @@ async def track_instance(
                 step_info["group"] = task_group
             step_progress.append(step_info)
 
+    # Progress is computed over visible steps only (skipped branches and
+    # internal gates excluded) so branched workflows report accurate progress.
+    total_steps = len(step_progress)
+    completed_steps = sum(1 for s in step_progress if s["status"] == "completed")
     progress_percentage = (completed_steps / total_steps * 100) if total_steps > 0 else 0
+
+    # Resolve entities emitted by the workflow so the portal can show them
+    # inline once the trámite concludes. Keep this light: ids/types only, never
+    # entity.data (which may carry heavy base64 payloads). The portal fetches
+    # full detail on demand via GET /public/entities/{id}.
+    emitted_entities = []
+    if dag_instance:
+        ctx = dag_instance.context or {}
+        seen_entity_ids = set()
+
+        def _add_entity(entity_id, entity_type):
+            if isinstance(entity_id, str) and entity_id and entity_id not in seen_entity_ids:
+                seen_entity_ids.add(entity_id)
+                emitted_entities.append({"entity_id": entity_id, "entity_type": entity_type})
+
+        # Prefer created_entity_<type> keys (they carry the entity type).
+        for key, value in ctx.items():
+            if key.startswith("created_entity_"):
+                _add_entity(value, key[len("created_entity_"):])
+        # Then any *_entity_id outputs not already captured.
+        for key, value in ctx.items():
+            if key.endswith("_entity_id"):
+                type_key = key[:-len("_entity_id")] + "_entity_type"
+                _add_entity(value, ctx.get(type_key))
 
     # Get workflow info
     workflow = await workflow_service.get_workflow_definition(db_instance.workflow_id)
@@ -426,6 +496,8 @@ async def track_instance(
         "requires_input": requires_input,
         "input_form": input_form,
         "waiting_for": waiting_for,
+        "route_label": route_label,
+        "emitted_entities": emitted_entities,
         "estimated_completion": None,
         "message": f"Workflow {db_instance.status}"
     }

--- a/backend/app/services/keycloak_sync.py
+++ b/backend/app/services/keycloak_sync.py
@@ -37,6 +37,11 @@ class KeycloakSyncService:
         self._admin_token = None
         self._admin_token_expires = None
 
+        # Cache for identity providers list (short TTL)
+        self._idp_cache: Optional[List[Dict[str, str]]] = None
+        self._idp_cache_expires: float = 0
+        self._idp_cache_ttl = 300  # seconds
+
         logger.info(f"KeycloakSyncService initialized for realm: {self.realm}")
 
     async def _get_admin_token(self) -> str:
@@ -110,6 +115,43 @@ class KeycloakSyncService:
                 result_data = {}
 
             return response.status_code, result_data
+
+    async def get_identity_providers(self) -> List[Dict[str, str]]:
+        """Get enabled identity providers configured for the citizen realm.
+
+        Returns a list of {alias, displayName} for each enabled provider so the
+        citizen portal can render login buttons dynamically. Cached for a short
+        TTL to avoid hitting the admin API on every page load.
+        """
+        now = datetime.utcnow().timestamp()
+        if self._idp_cache is not None and now < self._idp_cache_expires:
+            return self._idp_cache
+
+        try:
+            status_code, providers = await self._make_admin_request(
+                "GET", "/identity-provider/instances"
+            )
+        except Exception as e:
+            logger.error(f"Failed to fetch identity providers: {e}")
+            # Serve stale cache if available, otherwise empty
+            return self._idp_cache or []
+
+        if status_code != 200 or not isinstance(providers, list):
+            logger.warning(f"Identity providers request returned {status_code}")
+            return self._idp_cache or []
+
+        result = [
+            {
+                "alias": p["alias"],
+                "displayName": p.get("displayName") or p["alias"],
+            }
+            for p in providers
+            if p.get("enabled", True) and p.get("alias")
+        ]
+
+        self._idp_cache = result
+        self._idp_cache_expires = now + self._idp_cache_ttl
+        return result
 
     async def sync_user_to_keycloak(self, user: UserModel) -> bool:
         """Sync a user from MuniStream to Keycloak"""


### PR DESCRIPTION
## Qué

Agrega `GET /api/v1/public/identity-providers`, que lista los proveedores de identidad habilitados del realm (`alias` + `displayName`) consultando la Admin API de Keycloak, con caché de TTL corto en `KeycloakSyncService`.

## Por qué

El portal ciudadano necesita renderizar botones de inicio de sesión por IdP (p. ej. LlaveMX) de forma **dinámica**, sin hardcodear proveedores. Keycloak no expone los IdP de un realm en un endpoint público, por eso se hace vía Admin API en el backend.

## Notas

- Endpoint público (sin auth); la info no es sensible (los mismos botones aparecen hoy en la pantalla de Keycloak).
- Requiere que el backend tenga credenciales admin de Keycloak en su entorno (ya usadas por `KeycloakSyncService` para sync de usuarios).
- Si no hay IdP configurados, devuelve lista vacía.

## Pruebas

Verificado contra Keycloak local: con un IdP creado devuelve `{alias, displayName}`; sin IdP devuelve `[]`. Token admin obtenido y query a `/identity-provider/instances` con HTTP 200.