### PR TITLE
feat(auth): perfil LlaveMX en Customer + punto de extensión post-auth

### DIFF
--- a/backend/app/api/endpoints/public_auth.py
+++ b/backend/app/api/endpoints/public_auth.py
@@ -4,7 +4,8 @@ Separate from admin authentication.
 """
 
 from datetime import datetime, timedelta
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
+import json
 from fastapi import APIRouter, HTTPException, status, Header, Depends
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -73,6 +74,82 @@ def create_customer_access_token(data: dict, expires_delta: Optional[timedelta] 
     return encoded_jwt
 
 
+def _parse_personas_morales(raw: Any) -> List[Dict[str, Any]]:
+    """
+    Normalize the `personas_morales` token claim into a list of dicts.
+
+    The shim encodes the personas morales list as a JSON string so it survives
+    the OIDC -> Keycloak -> backend hop. Keycloak may also deliver it already
+    parsed (list) depending on the mapper's jsonType. Be tolerant of both and
+    never raise on malformed input (a citizen without a persona moral logs in
+    fine with an empty list).
+    """
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, list) else []
+        except (ValueError, TypeError):
+            logger.warning("Could not parse personas_morales claim as JSON")
+            return []
+    return []
+
+
+def _sync_llavemx_profile(customer: Customer, payload: Dict[str, Any]) -> None:
+    """
+    Sync Llave MX identity data from the Keycloak token claims into the Customer.
+
+    Called on every authenticated request so the MuniStream profile mirrors the
+    FORCE-synced Keycloak attributes (persona física + all associated personas
+    morales). Only overwrites fields when the corresponding claim is present.
+    """
+    curp = payload.get("curp")
+    rfc = payload.get("rfc")
+    tipo_persona = payload.get("tipo_persona")
+    llavemx_user_id = payload.get("llavemx_user_id")
+    phone = payload.get("phone") or payload.get("phone_number")
+    personas_morales = _parse_personas_morales(payload.get("personas_morales"))
+
+    changed = False
+    if curp and customer.curp != curp:
+        customer.curp = curp
+        changed = True
+    if rfc and customer.rfc != rfc:
+        customer.rfc = rfc
+        changed = True
+    if tipo_persona and customer.tipo_persona != tipo_persona:
+        customer.tipo_persona = tipo_persona
+        changed = True
+    if llavemx_user_id is not None and customer.llavemx_user_id != str(llavemx_user_id):
+        customer.llavemx_user_id = str(llavemx_user_id)
+        changed = True
+    if phone and customer.phone != phone:
+        customer.phone = phone
+        changed = True
+
+    # Store the full structured Llave MX profile in metadata.
+    if not isinstance(customer.metadata, dict):
+        customer.metadata = {}
+    llavemx_meta = {
+        "curp": curp,
+        "rfc": rfc,
+        "tipo_persona": tipo_persona,
+        "llavemx_user_id": str(llavemx_user_id) if llavemx_user_id is not None else None,
+        "razon_social": payload.get("razon_social"),
+        "personas_morales": personas_morales,
+        "synced_at": datetime.utcnow().isoformat(),
+    }
+    if customer.metadata.get("llavemx") != llavemx_meta:
+        customer.metadata["llavemx"] = llavemx_meta
+        changed = True
+
+    if changed:
+        customer.updated_at = datetime.utcnow()
+
+
 async def get_current_customer(authorization: Optional[str] = Header(None)) -> Customer:
     """
     Get current authenticated customer from Keycloak token.
@@ -121,15 +198,25 @@ async def get_current_customer(authorization: Optional[str] = Header(None)) -> C
         logger.error(f"Token verification failed: {e}")
         raise credentials_exception
 
-    # Get or create customer from Keycloak user info
-    # Use email as the unique identifier to find existing customers
+    # Resolve the customer. Prefer keycloak_id / curp to find the right record
+    # even when email is absent or changed, then fall back to email.
     email = payload.get("email", "")
-    if not email:
-        raise credentials_exception
+    curp = payload.get("curp")
 
-    customer = await Customer.find_one(Customer.email == email)
+    customer = await Customer.find_one(Customer.keycloak_id == customer_id)
+    if customer is None and curp:
+        customer = await Customer.find_one(Customer.curp == curp)
+    if customer is None and email:
+        customer = await Customer.find_one(Customer.email == email)
+
     if customer is None:
-        # Create customer from Keycloak token if doesn't exist
+        # Create customer from Keycloak token if it doesn't exist.
+        # Customer.email is required/unique; Llave MX accounts carry a correo,
+        # but fall back to a CURP-derived address if absent.
+        if not email:
+            if not curp:
+                raise credentials_exception
+            email = f"{curp}@llavemx.local"
         username = payload.get("preferred_username", email)
         name = payload.get("name", username)
 
@@ -137,14 +224,20 @@ async def get_current_customer(authorization: Optional[str] = Header(None)) -> C
             # Don't set id - let MongoDB generate it
             email=email,
             full_name=name,
-            phone=payload.get("phone", ""),
-            document_number="",
+            phone=payload.get("phone") or payload.get("phone_number") or "",
+            document_number=curp or "",
             password_hash="",  # No password needed with Keycloak
             status=CustomerStatus.ACTIVE,
             email_verified=payload.get("email_verified", False),
             keycloak_id=customer_id  # Store Keycloak ID separately
         )
-        await customer.save()
+
+    # Keep the Keycloak link fresh and sync Llave MX data on every login.
+    if customer.keycloak_id != customer_id:
+        customer.keycloak_id = customer_id
+    _sync_llavemx_profile(customer, payload)
+    customer.update_last_login()
+    await customer.save()
 
     return customer
 

--- a/backend/app/api/endpoints/public_auth.py
+++ b/backend/app/api/endpoints/public_auth.py
@@ -15,6 +15,7 @@ import logging
 from ...models.customer import Customer, CustomerStatus
 from ...core.config import settings
 from ...core.i18n import t as translate
+from ...auth.auth_callbacks import run_post_auth_callbacks
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +239,10 @@ async def get_current_customer(authorization: Optional[str] = Header(None)) -> C
     _sync_llavemx_profile(customer, payload)
     customer.update_last_login()
     await customer.save()
+
+    # Run plugin-registered post-auth callbacks (e.g. tenant-specific entity sync).
+    # Runs after save so customer.id is assigned; callbacks persist their own changes.
+    await run_post_auth_callbacks(customer, payload, settings.TENANT_ID)
 
     return customer
 

--- a/backend/app/auth/auth_callbacks.py
+++ b/backend/app/auth/auth_callbacks.py
@@ -1,0 +1,60 @@
+"""
+Generic post-authentication callback registry.
+
+Plugins (or any module loaded at startup) may register async callbacks that run
+on every authenticated citizen request, right after the Customer record has been
+resolved/synced. The backend stays agnostic: it does not know what the callbacks
+do, and registering none is a no-op.
+
+A callback has the signature:
+
+    async def callback(customer, payload, tenant_id) -> None
+
+where `customer` is the resolved Customer document, `payload` is the verified
+token claims dict, and `tenant_id` is the backend's configured tenant (may be
+None). Exceptions raised by a callback are logged and swallowed so a failing
+extension never breaks authentication.
+"""
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+PostAuthCallback = Callable[[Any, Dict[str, Any], Optional[str]], Awaitable[None]]
+
+_post_auth_callbacks: List[PostAuthCallback] = []
+
+
+def register_post_auth_callback(callback: PostAuthCallback) -> None:
+    """Register a callback to run after a citizen is authenticated.
+
+    Idempotent: registering the same callable twice is ignored so a plugin
+    reload does not stack duplicates.
+    """
+    if callback not in _post_auth_callbacks:
+        _post_auth_callbacks.append(callback)
+        logger.info(
+            "Registered post-auth callback: %s",
+            getattr(callback, "__qualname__", repr(callback)),
+        )
+
+
+def clear_post_auth_callbacks() -> None:
+    """Remove all registered callbacks (used by tests)."""
+    _post_auth_callbacks.clear()
+
+
+async def run_post_auth_callbacks(
+    customer: Any,
+    payload: Dict[str, Any],
+    tenant_id: Optional[str] = None,
+) -> None:
+    """Run all registered post-auth callbacks, isolating failures."""
+    for callback in _post_auth_callbacks:
+        try:
+            await callback(customer, payload, tenant_id)
+        except Exception:
+            logger.exception(
+                "post-auth callback failed: %s",
+                getattr(callback, "__qualname__", repr(callback)),
+            )

--- a/backend/app/models/customer.py
+++ b/backend/app/models/customer.py
@@ -33,6 +33,14 @@ class Customer(Document):
     phone: Optional[str] = None
     document_number: Optional[str] = None
     keycloak_id: Optional[str] = None  # Keycloak user ID for SSO users
+
+    # Llave MX identity data (synced from Keycloak token on every login)
+    curp: Optional[str] = None
+    rfc: Optional[str] = None
+    tipo_persona: Optional[str] = None  # "fisica" | "moral"
+    llavemx_user_id: Optional[str] = None
+    # Full structured Llave MX profile (incl. personas_morales array) lives in
+    # metadata["llavemx"]; the typed fields above mirror the key scalars.
     
     # Account Status
     status: CustomerStatus = CustomerStatus.ACTIVE
@@ -55,6 +63,8 @@ class Customer(Document):
         indexes = [
             "email",
             "document_number",
+            "curp",
+            "rfc",
             "created_at"
         ]
     
@@ -69,6 +79,7 @@ class Customer(Document):
     
     def to_public_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for public API responses"""
+        llavemx = self.metadata.get("llavemx", {}) if isinstance(self.metadata, dict) else {}
         return {
             "id": str(self.id),
             "email": self.email,
@@ -78,7 +89,12 @@ class Customer(Document):
             "status": self.status,
             "email_verified": self.email_verified,
             "created_at": self.created_at,
-            "last_login_at": self.last_login_at
+            "last_login_at": self.last_login_at,
+            # Llave MX identity data
+            "curp": self.curp,
+            "rfc": self.rfc,
+            "tipo_persona": self.tipo_persona,
+            "personas_morales": llavemx.get("personas_morales", []),
         }
 
 

--- a/backend/app/workflows/plugin_loader.py
+++ b/backend/app/workflows/plugin_loader.py
@@ -32,6 +32,7 @@ class WorkflowPlugin:
         self.version = config.get("version", "1.0.0")
         self.workflows = config.get("workflows", [])
         self.visualizers = config.get("visualizers", [])
+        self.extensions = config.get("extensions", [])
         self.local_path = None
         
     def clone_or_update(self, base_path: str = "/tmp/civicstream_plugins") -> str:
@@ -241,6 +242,71 @@ class WorkflowPlugin:
 
         return loaded_count
     
+    def load_extensions(self) -> int:
+        """Load runtime extensions from the plugin.
+
+        An extension is a module exposing a parameterless registration function
+        (``register`` by default). The function is called once at startup so the
+        plugin can wire tenant-specific runtime behavior (e.g. register a
+        post-auth callback) without the shared backend knowing about it.
+        """
+        if not self.local_path:
+            raise ValueError("Plugin not cloned yet. Call clone_or_update first.")
+
+        loaded_count = 0
+        errors = []
+
+        # Add plugin path to Python path
+        if self.local_path not in sys.path:
+            sys.path.insert(0, self.local_path)
+
+        try:
+            print(f"🔌 DEBUG: Processing {len(self.extensions)} extensions for plugin {self.name}")
+
+            for extension_info in self.extensions:
+                module_path = extension_info.get("module")
+                function_name = extension_info.get("function", "register")
+
+                if not module_path:
+                    error_msg = f"Skipping extension with missing module: {extension_info}"
+                    print(f"⚠️ {error_msg}")
+                    errors.append(error_msg)
+                    continue
+
+                try:
+                    module = importlib.import_module(module_path)
+                    register_func = getattr(module, function_name, None)
+
+                    if callable(register_func):
+                        register_func()
+                        loaded_count += 1
+                        print(f"✅ Loaded extension: {module_path}.{function_name} from {self.name}")
+                    else:
+                        error_msg = f"Module {module_path} has no callable {function_name}"
+                        print(f"❌ {error_msg}")
+                        errors.append(error_msg)
+
+                except ImportError as e:
+                    error_msg = f"Failed to import {module_path}: {str(e)}"
+                    print(f"❌ {error_msg}")
+                    errors.append(error_msg)
+                except Exception as e:
+                    error_msg = f"Error loading extension {module_path}.{function_name}: {str(e)}"
+                    print(f"❌ {error_msg}")
+                    errors.append(error_msg)
+
+        finally:
+            # Clean up sys.path
+            if self.local_path in sys.path:
+                sys.path.remove(self.local_path)
+
+        if errors:
+            print(f"⚠️ Plugin {self.name} had {len(errors)} errors during extension loading")
+            for error in errors:
+                print(f"   - {error}")
+
+        return loaded_count
+
     def _auto_discover_workflows(self) -> List[Dict[str, str]]:
         """Auto-discover workflows by scanning for DAG files"""
         discovered = []
@@ -420,6 +486,10 @@ class WorkflowPluginManager:
         # Now that all repositories are cloned, load visualizers from both local config and plugin repos
         print(f"\n🎨 Loading visualizers...")
         self._load_visualizers()
+
+        # Load runtime extensions (e.g. tenant-specific post-auth hooks)
+        print(f"\n🔌 Loading extensions...")
+        self._load_extensions()
         print(f"{'='*60}\n")
 
         return total_loaded
@@ -485,6 +555,24 @@ class WorkflowPluginManager:
 
         if total_visualizer_count > 0:
             print(f"   ✅ Total visualizers loaded: {total_visualizer_count}")
+
+    def _load_extensions(self):
+        """Load runtime extensions from all plugins"""
+        total_extension_count = 0
+
+        print(f"   Loading extensions from {len(self.plugins)} plugins...")
+        for plugin in self.plugins:
+            if plugin.extensions:
+                try:
+                    extension_count = plugin.load_extensions()
+                    total_extension_count += extension_count
+                    if extension_count > 0:
+                        print(f"   ✅ Loaded {extension_count} extension(s) from {plugin.name}")
+                except Exception as e:
+                    print(f"   ⚠️ Error loading extensions from {plugin.name}: {e}")
+
+        if total_extension_count > 0:
+            print(f"   ✅ Total extensions loaded: {total_extension_count}")
 
 
 # Example plugin configuration file (plugins.yaml):


### PR DESCRIPTION
## Resumen

Lleva a main la cadena LlaveMX del lado backend (2 commits):

1. **`427ba9d` feat(auth): sincroniza datos LlaveMX (persona física/moral) en el Customer** — en cada request autenticado vuelca los claims LlaveMX del token (curp, rfc, tipo_persona, personas_morales, …) a `customer.metadata['llavemx']` y a los campos escalares del Customer.

2. **`68bb65a` feat(auth): punto de extensión post-auth genérico para plugins** — registro genérico de callbacks (`app/auth/auth_callbacks.py`) que corre en `get_current_customer` tras resolver/sincronizar el Customer, más soporte para una sección `extensions` en `plugins.yaml` del plugin loader. El backend queda agnóstico del tenant.

## Por qué

Habilita que los plugins de tenant enganchen comportamiento de runtime en el login sin que el backend compartido conozca al tenant. El primer consumidor es el hook de CONAPESCA que materializa entidades persona física / personas morales desde LlaveMX (plugin PR TrazabilidadCONAPESCA#123).

## Pruebas

- E2E real con login Keycloak (atributos LlaveMX → endpoint autenticado).
- Carga de la sección `extensions` confirmada en el startup.
- Los callbacks fallan de forma aislada (try/except) para no romper la autenticación.