### PR TITLE
feat: validación server-side de constraints y unificación de template PDF

### DIFF
--- a/backend/app/api/endpoints/signatures.py
+++ b/backend/app/api/endpoints/signatures.py
@@ -329,6 +329,21 @@ async def verify_entity_signature(
         raise HTTPException(status_code=500, detail="Signature verification failed")
 
 
+def _select_entity_visualizer(entity) -> str:
+    """Select the visualizer for an entity.
+
+    Single source of truth so the downloaded PDF, the in-browser HTML view and
+    the printed output all render with the SAME template. The entity's
+    configured visualizer always wins; ``signed_pdf`` is only a fallback for
+    signed entities that have no configured visualizer.
+    """
+    if entity.entity_display_config and entity.entity_display_config.get("visualizer"):
+        return entity.entity_display_config["visualizer"]
+    if entity.data and "signature" in entity.data:
+        return "signed_pdf"
+    return "pdf_report"
+
+
 @router.get("/entities/{entity_id}/pdf")
 async def get_entity_pdf(
     entity_id: str,
@@ -344,14 +359,9 @@ async def get_entity_pdf(
         if not entity:
             raise HTTPException(status_code=404, detail="Entity not found")
 
-        # Determine visualizer from entity configuration only (security)
-        visualizer = "pdf_report"  # Safe default
-        if entity.entity_display_config and "visualizer" in entity.entity_display_config:
-            visualizer = entity.entity_display_config["visualizer"]
-
-        # Override for signed documents
-        if include_signatures and entity.data and "signature" in entity.data:
-            visualizer = "signed_pdf"
+        # Use the SAME visualizer selection as the HTML view so the downloaded
+        # PDF matches exactly what the citizen visualizes and prints.
+        visualizer = _select_entity_visualizer(entity)
 
         # Get base URL for frontend (citizen portal) - used for QR codes and verification links
         from app.core.config import settings
@@ -410,9 +420,8 @@ async def get_entity_preview(
         if not entity:
             raise HTTPException(status_code=404, detail="Entity not found")
 
-        # Determine visualizer type
-        if entity.data and "signature" in entity.data:
-            visualizer = "signed_pdf"
+        # Same visualizer selection as the PDF download and HTML view.
+        visualizer = _select_entity_visualizer(entity)
 
         # Get base URL for frontend (citizen portal) - used for QR codes and verification links
         from app.core.config import settings
@@ -471,11 +480,9 @@ async def get_entity_html(
         if not entity:
             raise HTTPException(status_code=404, detail="Entity not found")
 
-        # Determine visualizer type based on entity configuration
-        if entity.entity_display_config and "visualizer" in entity.entity_display_config:
-            visualizer = entity.entity_display_config["visualizer"]
-        elif entity.data and "signature" in entity.data:
-            visualizer = "signed_pdf"
+        # Same visualizer selection as the PDF download so view, print and
+        # download all share the same template.
+        visualizer = _select_entity_visualizer(entity)
 
         # Get base URL for frontend (citizen portal) - used for QR codes and verification links
         from app.core.config import settings

--- a/backend/app/workflows/operators/user_input.py
+++ b/backend/app/workflows/operators/user_input.py
@@ -1,8 +1,21 @@
 """
 Simple, stateless User Input Operator.
 """
+import re
+from datetime import date, datetime
 from typing import Dict, Any, List, Optional
 from .base import BaseOperator, TaskResult, TaskStatus
+
+
+def _constraint(field_cfg: Dict[str, Any], key: str) -> Any:
+    """Read a constraint declared at the field root or under `validation`.
+    Root takes priority (the convention used by top-level workflow fields)."""
+    if field_cfg.get(key) is not None:
+        return field_cfg.get(key)
+    validation = field_cfg.get("validation")
+    if isinstance(validation, dict):
+        return validation.get(key)
+    return None
 
 
 def _item_field_visible(item_field: Dict[str, Any], item: Dict[str, Any]) -> bool:
@@ -105,6 +118,52 @@ class UserInputOperator(BaseOperator):
                 errors.append(f"Required field: {field}")
 
         fields_schema = self.form_config.get("fields", []) if isinstance(self.form_config, dict) else []
+
+        # Scalar field constraints (number min/max, text length/pattern, date minToday).
+        # These are authoritative server-side checks; the frontend mirrors them.
+        for field_cfg in fields_schema:
+            ftype = field_cfg.get("type")
+            if ftype in ("array", "file", "camera", None):
+                continue
+            name = field_cfg.get("name")
+            label = field_cfg.get("label", name)
+            value = user_input.get(name)
+            if value in (None, "", []):
+                continue
+
+            if ftype == "number":
+                try:
+                    num = float(value)
+                except (TypeError, ValueError):
+                    errors.append(f"{label} debe ser numérico")
+                    continue
+                min_v = _constraint(field_cfg, "min")
+                max_v = _constraint(field_cfg, "max")
+                if min_v is not None and num < float(min_v):
+                    errors.append(f"{label} debe ser al menos {min_v}")
+                if max_v is not None and num > float(max_v):
+                    errors.append(f"{label} no debe ser mayor que {max_v}")
+            elif ftype in ("text", "email", "phone", "textarea"):
+                text = str(value)
+                min_len = _constraint(field_cfg, "minLength")
+                max_len = _constraint(field_cfg, "maxLength")
+                pattern = _constraint(field_cfg, "pattern")
+                if min_len is not None and len(text) < int(min_len):
+                    errors.append(f"{label} debe tener al menos {min_len} caracteres")
+                if max_len is not None and len(text) > int(max_len):
+                    errors.append(f"{label} no debe tener más de {max_len} caracteres")
+                if pattern and not re.fullmatch(pattern, text):
+                    errors.append(f"{label} tiene un formato inválido")
+            elif ftype == "date":
+                if field_cfg.get("minToday"):
+                    try:
+                        selected = datetime.fromisoformat(str(value)[:10]).date()
+                    except ValueError:
+                        errors.append(f"{label} tiene una fecha inválida")
+                    else:
+                        if selected < date.today():
+                            errors.append(f"{label} no puede ser anterior a la fecha actual")
+
         for field_cfg in fields_schema:
             if field_cfg.get("type") != "array":
                 continue


### PR DESCRIPTION
## Resumen
Dos correcciones de raíz para CONAPESCA (y aplicables a todos los tenants):

### 1. Validación server-side de constraints (`user_input.py`)
`_validate_input` ahora aplica los constraints declarados en la raíz del campo, que antes se ignoraban en el servidor:
- `number`: `min`/`max`
- `text`/`textarea`/`email`/`phone`: `minLength`/`maxLength`/`pattern`
- `date`: `minToday` (no permite fechas retroactivas)

Resuelve casos como potencia del motor >115 HP, eslora fuera de rango, número de registro >7 dígitos y fechas retroactivas que se aceptaban indebidamente.

### 2. Unificación del template PDF (`signatures.py`)
Nuevo helper `_select_entity_visualizer()` usado por `/pdf`, `/html` y `/preview`, de modo que **descargar = visualizar = imprimir** usan el mismo visualizer/template (antes la descarga forzaba `signed_pdf` para documentos firmados, divergiendo de la vista).

## Pruebas
- Tests in-process contra Mongo real: rechaza valores fuera de rango.
- E2E en vivo (documentación de embarcación): validación aplicada por el servidor.
- `/pdf` y `/html` verificados 200 con el mismo template.