### PR TITLE
feat(analytics): StepExecution por paso + endpoint consolidado de analíticas

### DIFF
--- a/backend/app/api/v1/performance.py
+++ b/backend/app/api/v1/performance.py
@@ -2,6 +2,7 @@
 Performance monitoring and analytics API endpoints.
 """
 
+from datetime import datetime, timedelta
 from typing import Dict, Any, List, Optional
 from fastapi import APIRouter, HTTPException, Query, Depends
 from pydantic import BaseModel, Field
@@ -9,6 +10,29 @@ from pydantic import BaseModel, Field
 from ...services.workflow_service import workflow_service
 
 router = APIRouter()
+
+
+def _median(values: List[float]) -> Optional[float]:
+    """Median of a list of numbers (None when empty)."""
+    if not values:
+        return None
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    if n % 2:
+        return s[mid]
+    return (s[mid - 1] + s[mid]) / 2
+
+
+def _percentile(values: List[float], pct: float) -> Optional[float]:
+    """Nearest-rank percentile of a list of numbers (None when empty)."""
+    if not values:
+        return None
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = int(round((pct / 100.0) * (len(s) - 1)))
+    return s[k]
 
 
 class StepExecutionRequest(BaseModel):
@@ -63,6 +87,256 @@ class BottleneckAnalysisResponse(BaseModel):
     external_service_bottlenecks: List[Dict[str, Any]]
     queue_bottlenecks: List[Dict[str, Any]]
     recommendations: List[str]
+
+
+class EfficiencyKPIs(BaseModel):
+    """Instance-level efficiency indicators for a workflow"""
+    total_instances: int
+    active_instances: int
+    completed_instances: int
+    failed_instances: int
+    completion_rate: float
+    avg_duration_seconds: Optional[float] = None
+    median_duration_seconds: Optional[float] = None
+    overall_efficiency: float
+
+
+class StepBottleneck(BaseModel):
+    """Per-step dwell-time bottleneck indicator"""
+    step_id: str
+    step_name: str
+    avg_duration_seconds: Optional[float] = None
+    p95_duration_seconds: Optional[float] = None
+    execution_count: int
+    currently_stuck_count: int
+    severity: str
+
+
+class StatusCount(BaseModel):
+    """Instance count for a status value"""
+    status: str
+    count: int
+
+
+class VolumePoint(BaseModel):
+    """Daily started/completed instance counts"""
+    date: str
+    started: int
+    completed: int
+
+
+class WorkflowAnalyticsResponse(BaseModel):
+    """Consolidated analytics for a single workflow"""
+    workflow_id: str
+    generated_at: datetime
+    kpis: EfficiencyKPIs
+    bottlenecks: List[StepBottleneck]
+    status_distribution: List[StatusCount]
+    volume_over_time: List[VolumePoint]
+
+
+@router.get("/workflows/{workflow_id}/analytics", response_model=WorkflowAnalyticsResponse)
+async def get_workflow_analytics(
+    workflow_id: str,
+    days: int = Query(30, description="Time window in days for the volume series"),
+    stuck_threshold_hours: int = Query(24, description="Hours idle before an active instance counts as stuck"),
+):
+    """Consolidated analytics for a workflow: efficiency KPIs, per-step
+    bottlenecks, status distribution and volume over time. Computed from real
+    WorkflowInstance and StepExecution data via native MongoDB aggregation."""
+    from ...models.workflow import WorkflowInstance, StepExecution, WorkflowStep
+
+    dag = await workflow_service.get_dag(workflow_id)
+    if not dag:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    try:
+        now = datetime.utcnow()
+        active_statuses = ["pending", "running", "paused"]
+
+        # ---- (a) Efficiency KPIs -------------------------------------------
+        kpi_pipeline = [
+            {"$match": {"workflow_id": workflow_id}},
+            {"$addFields": {"_dur": {"$ifNull": [
+                "$duration_seconds",
+                {"$cond": [
+                    {"$and": [
+                        {"$ne": ["$completed_at", None]},
+                        {"$ne": ["$started_at", None]},
+                    ]},
+                    {"$divide": [{"$subtract": ["$completed_at", "$started_at"]}, 1000]},
+                    None,
+                ]},
+            ]}}},
+            {"$group": {
+                "_id": None,
+                "total": {"$sum": 1},
+                "completed": {"$sum": {"$cond": [{"$eq": ["$status", "completed"]}, 1, 0]}},
+                "failed": {"$sum": {"$cond": [{"$eq": ["$status", "failed"]}, 1, 0]}},
+                "active": {"$sum": {"$cond": [{"$in": ["$status", active_statuses]}, 1, 0]}},
+                "avg_duration": {"$avg": "$_dur"},
+                "durations": {"$push": "$_dur"},
+            }},
+        ]
+        kpi_rows = await WorkflowInstance.aggregate(kpi_pipeline).to_list()
+        if kpi_rows:
+            row = kpi_rows[0]
+            total = row.get("total", 0)
+            completed = row.get("completed", 0)
+            failed = row.get("failed", 0)
+            active = row.get("active", 0)
+            durations = [d for d in row.get("durations", []) if d is not None]
+            median_duration = _median(durations)
+            avg_duration = row.get("avg_duration")
+        else:
+            total = completed = failed = active = 0
+            median_duration = None
+            avg_duration = None
+
+        completion_rate = (completed / total * 100) if total else 0.0
+        efficiency_denom = completed + failed
+        overall_efficiency = (completed / efficiency_denom * 100) if efficiency_denom else 0.0
+
+        kpis = EfficiencyKPIs(
+            total_instances=total,
+            active_instances=active,
+            completed_instances=completed,
+            failed_instances=failed,
+            completion_rate=round(completion_rate, 2),
+            avg_duration_seconds=round(avg_duration, 2) if avg_duration is not None else None,
+            median_duration_seconds=round(median_duration, 2) if median_duration is not None else None,
+            overall_efficiency=round(overall_efficiency, 2),
+        )
+
+        # ---- (b) Per-step bottlenecks --------------------------------------
+        step_pipeline = [
+            {"$match": {"workflow_id": workflow_id, "duration_seconds": {"$ne": None}}},
+            {"$group": {
+                "_id": "$step_id",
+                "execution_count": {"$sum": 1},
+                "avg_duration": {"$avg": "$duration_seconds"},
+                "durations": {"$push": "$duration_seconds"},
+            }},
+        ]
+        step_rows = await StepExecution.aggregate(step_pipeline).to_list()
+
+        stuck_pipeline = [
+            {"$match": {
+                "workflow_id": workflow_id,
+                "status": {"$in": active_statuses},
+                "current_step": {"$ne": None},
+                "updated_at": {"$lt": now - timedelta(hours=stuck_threshold_hours)},
+            }},
+            {"$group": {"_id": "$current_step", "count": {"$sum": 1}}},
+        ]
+        stuck_rows = await WorkflowInstance.aggregate(stuck_pipeline).to_list()
+        stuck_by_step = {r["_id"]: r["count"] for r in stuck_rows if r.get("_id")}
+
+        step_defs = await WorkflowStep.find(WorkflowStep.workflow_id == workflow_id).to_list()
+        name_by_step = {s.step_id: s.name for s in step_defs}
+
+        metrics_by_step: Dict[str, Dict[str, Any]] = {}
+        for r in step_rows:
+            sid = r["_id"]
+            durs = [d for d in r.get("durations", []) if d is not None]
+            metrics_by_step[sid] = {
+                "execution_count": r.get("execution_count", 0),
+                "avg_duration": r.get("avg_duration"),
+                "p95": _percentile(durs, 95),
+            }
+
+        # Union of steps with executions and steps holding stuck instances.
+        all_step_ids = set(metrics_by_step) | set(stuck_by_step)
+
+        # Severity by dwell ranking; escalate any step with stuck instances.
+        ranked = sorted(
+            [sid for sid in all_step_ids if metrics_by_step.get(sid, {}).get("avg_duration") is not None],
+            key=lambda s: metrics_by_step[s]["avg_duration"],
+            reverse=True,
+        )
+        severity_by_step: Dict[str, str] = {}
+        n = len(ranked)
+        for idx, sid in enumerate(ranked):
+            if idx == 0:
+                severity_by_step[sid] = "high"
+            elif idx < max(1, n // 4):
+                severity_by_step[sid] = "medium"
+            else:
+                severity_by_step[sid] = "low"
+
+        bottlenecks: List[StepBottleneck] = []
+        for sid in all_step_ids:
+            m = metrics_by_step.get(sid, {})
+            stuck = stuck_by_step.get(sid, 0)
+            severity = severity_by_step.get(sid, "none")
+            if stuck > 0 and severity != "high":
+                severity = "high"
+            avg = m.get("avg_duration")
+            p95 = m.get("p95")
+            bottlenecks.append(StepBottleneck(
+                step_id=sid,
+                step_name=name_by_step.get(sid) or sid.replace("_", " ").title(),
+                avg_duration_seconds=round(avg, 2) if avg is not None else None,
+                p95_duration_seconds=round(p95, 2) if p95 is not None else None,
+                execution_count=m.get("execution_count", 0),
+                currently_stuck_count=stuck,
+                severity=severity,
+            ))
+        bottlenecks.sort(
+            key=lambda b: (b.avg_duration_seconds or 0) * max(b.execution_count, 1),
+            reverse=True,
+        )
+
+        # ---- (c) Status distribution ---------------------------------------
+        status_pipeline = [
+            {"$match": {"workflow_id": workflow_id}},
+            {"$group": {"_id": "$status", "count": {"$sum": 1}}},
+            {"$sort": {"count": -1}},
+        ]
+        status_rows = await WorkflowInstance.aggregate(status_pipeline).to_list()
+        status_distribution = [
+            StatusCount(status=r["_id"] or "unknown", count=r["count"]) for r in status_rows
+        ]
+
+        # ---- (d) Volume over time ------------------------------------------
+        window_start = now - timedelta(days=days)
+        started_pipeline = [
+            {"$match": {"workflow_id": workflow_id, "started_at": {"$gte": window_start}}},
+            {"$group": {"_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$started_at"}}, "count": {"$sum": 1}}},
+        ]
+        completed_pipeline = [
+            {"$match": {"workflow_id": workflow_id, "completed_at": {"$gte": window_start}}},
+            {"$group": {"_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$completed_at"}}, "count": {"$sum": 1}}},
+        ]
+        started_rows = await WorkflowInstance.aggregate(started_pipeline).to_list()
+        completed_rows = await WorkflowInstance.aggregate(completed_pipeline).to_list()
+        started_by_day = {r["_id"]: r["count"] for r in started_rows if r.get("_id")}
+        completed_by_day = {r["_id"]: r["count"] for r in completed_rows if r.get("_id")}
+
+        volume_over_time: List[VolumePoint] = []
+        day = window_start.date()
+        end_day = now.date()
+        while day <= end_day:
+            key = day.strftime("%Y-%m-%d")
+            volume_over_time.append(VolumePoint(
+                date=key,
+                started=started_by_day.get(key, 0),
+                completed=completed_by_day.get(key, 0),
+            ))
+            day += timedelta(days=1)
+
+        return WorkflowAnalyticsResponse(
+            workflow_id=workflow_id,
+            generated_at=now,
+            kpis=kpis,
+            bottlenecks=bottlenecks,
+            status_distribution=status_distribution,
+            volume_over_time=volume_over_time,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to compute workflow analytics: {str(e)}")
 
 
 @router.get("/steps/{step_id}/metrics", response_model=PerformanceMetricsResponse)

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -736,6 +736,51 @@ class StepExecutionService:
             StepExecution.instance_id == instance_id
         ).sort(StepExecution.started_at).to_list()
 
+    @staticmethod
+    async def upsert_step_execution(
+        instance_id: str,
+        step_id: str,
+        workflow_id: str,
+        status: str,
+        started_at: datetime,
+        completed_at: Optional[datetime] = None,
+        error_message: Optional[str] = None
+    ) -> None:
+        """Idempotently record a completed step execution.
+
+        Dedup key is (instance_id, step_id, started_at):
+        - A retried step re-runs with a fresh started_at -> a new row.
+        - Re-persisting the same transition reuses started_at -> update, no dup.
+
+        Single Mongo round-trip; used by both the executor (live) and the
+        historical backfill so there is one source of truth for the write.
+        """
+        import uuid
+
+        duration_seconds = None
+        if started_at and completed_at:
+            duration_seconds = (completed_at - started_at).total_seconds()
+
+        now = datetime.utcnow()
+        await StepExecution.get_motor_collection().update_one(
+            {"instance_id": instance_id, "step_id": step_id, "started_at": started_at},
+            {
+                "$set": {
+                    "workflow_id": workflow_id,
+                    "status": status,
+                    "completed_at": completed_at,
+                    "duration_seconds": duration_seconds,
+                    "error_message": error_message,
+                    "updated_at": now,
+                },
+                "$setOnInsert": {
+                    "execution_id": str(uuid.uuid4()),
+                    "created_at": now,
+                },
+            },
+            upsert=True,
+        )
+
 
 class AuditService:
     """Service layer for audit logging"""

--- a/backend/app/workflows/dag.py
+++ b/backend/app/workflows/dag.py
@@ -387,7 +387,12 @@ class DAGInstance:
         self.updated_at = datetime.utcnow()
         
         if status == "executing":
-            self.task_states[task_id]["started_at"] = datetime.utcnow()
+            # Preserve the original start timestamp so a step that goes through a
+            # waiting/resume cycle (e.g. admin validation) reports its full dwell
+            # time instead of only the post-resume interval. Stamp started_at only
+            # the first time the task actually starts.
+            if not self.task_states[task_id]["started_at"]:
+                self.task_states[task_id]["started_at"] = datetime.utcnow()
             self.current_task = task_id
             
         elif status in ["completed", "continue"]:

--- a/backend/app/workflows/executor.py
+++ b/backend/app/workflows/executor.py
@@ -719,7 +719,7 @@ class DAGExecutor:
         }
         return mapping.get(dag_status, "running")
 
-    async def _save_instance_state(self, dag_instance, db_instance, instance_id, new_status=None):
+    async def _save_instance_state(self, dag_instance, db_instance, instance_id, new_status=None, record_executions=True):
         """Save instance state to database"""
         # Ensure instance_id and workflow_id are always saved in context
         dag_instance.context["instance_id"] = instance_id
@@ -753,6 +753,13 @@ class DAGExecutor:
         if dag_instance.completed_at:
             db_instance.completed_at = dag_instance.completed_at
 
+        # Record total wall-clock duration once the instance reaches a terminal
+        # state (the DAG executor path otherwise never populates duration_seconds).
+        if new_status in ("completed", "failed") and db_instance.duration_seconds is None:
+            end = db_instance.completed_at or dag_instance.completed_at
+            if db_instance.started_at and end:
+                db_instance.duration_seconds = (end - db_instance.started_at).total_seconds()
+
         await db_instance.save()
 
         if new_step and new_step != previous_step:
@@ -771,6 +778,63 @@ class DAGExecutor:
                 logger.exception(
                     "Failed to publish STEP_ADVANCED for instance %s", instance_id
                 )
+
+        if record_executions:
+            await self._record_step_executions(
+                dag_instance, db_instance, instance_id, previous_step, new_step, new_status
+            )
+
+    # Task states that mean a step reached a terminal outcome worth recording,
+    # mapped to the StepExecution.status vocabulary.
+    _TERMINAL_TASK_STATUS = {
+        "completed": "completed",
+        "continue": "completed",
+        "failed": "failed",
+        "skipped": "skipped",
+    }
+
+    async def _record_step_executions(
+        self, dag_instance, db_instance, instance_id, previous_step, new_step, new_status
+    ):
+        """Persist StepExecution rows for steps that just reached a terminal state.
+
+        Runs after the instance is saved and never raises into the execution loop:
+        analytics must not be able to break or block workflow execution. Dedup by
+        (instance_id, step_id, started_at) in upsert_step_execution keeps this
+        idempotent across repeated saves of the same transition.
+        """
+        try:
+            from ..services.workflow_service import StepExecutionService
+
+            candidates = []
+            # The step we just advanced away from has finished.
+            if new_step and previous_step and new_step != previous_step:
+                candidates.append(previous_step)
+            # On a terminal instance status the final/current task does not trigger
+            # a further transition, so capture it explicitly.
+            if new_status in ("completed", "failed") and dag_instance.current_task:
+                candidates.append(dag_instance.current_task)
+
+            for step_id in candidates:
+                ts = dag_instance.task_states.get(step_id)
+                if not ts or not ts.get("started_at"):
+                    continue
+                mapped = self._TERMINAL_TASK_STATUS.get(ts.get("status"))
+                if not mapped:
+                    continue
+                await StepExecutionService.upsert_step_execution(
+                    instance_id=instance_id,
+                    step_id=step_id,
+                    workflow_id=db_instance.workflow_id,
+                    status=mapped,
+                    started_at=ts["started_at"],
+                    completed_at=ts.get("completed_at"),
+                    error_message=ts.get("error"),
+                )
+        except Exception:
+            logger.exception(
+                "Failed to record StepExecution for instance %s", instance_id
+            )
 
     async def _execute_retry_workflow_reset(self, dag_instance, db_instance, instance_id,
                                           next_task_id, failed_task_id, recovery_data, recovery_action):
@@ -902,8 +966,10 @@ class DAGExecutor:
             for key in context_keys_to_remove:
                 del dag_instance.context[key]
 
-        # Save state to database
-        await self._save_instance_state(dag_instance, db_instance, instance_id)
+        # Save state to database. Skip StepExecution recording here: the reset
+        # re-points current_task to the retry target, which is not a real forward
+        # transition and would otherwise write a spurious execution row.
+        await self._save_instance_state(dag_instance, db_instance, instance_id, record_executions=False)
         return True
 
     async def _execution_loop(self):

--- a/backend/scripts/backfill_step_executions.py
+++ b/backend/scripts/backfill_step_executions.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Backfill StepExecution records from the historical STEP_ADVANCED event stream.
+
+The DAG executor only started persisting per-step timing (StepExecution rows)
+recently. For instances that ran before that change there is no per-step timing
+except the STEP_ADVANCED events in `workflow_events`, which stamp the moment each
+step handed off to the next. This script reconstructs per-step start/end times by
+diffing consecutive STEP_ADVANCED timestamps per instance and writes StepExecution
+rows so workflow analytics have real historical data.
+
+Idempotency: it uses a coarse guard — if any StepExecution already exists for an
+(instance_id, step_id) pair it skips that step. Historical instances have zero
+rows and get backfilled once; instances written by the live executor already have
+rows and are skipped entirely. (This collapses historical retries of the same step
+into a single row, which is acceptable for historical data.)
+
+Usage:
+    python scripts/backfill_step_executions.py [--workflow-id WF] [--dry-run] [--batch-size N]
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from collections import defaultdict
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from app.core.database import connect_to_mongo, close_mongo_connection
+from app.models.workflow import WorkflowEvent, WorkflowInstance, StepExecution, EventType
+from app.services.workflow_service import StepExecutionService
+
+
+def _reconstruct_steps(instance, events):
+    """Reconstruct (step_id, started_at, completed_at, status) tuples for one instance.
+
+    `events` are that instance's STEP_ADVANCED events sorted by timestamp asc.
+    Each event means: previous_step finished at event.timestamp and current_step
+    started at event.timestamp. Assumes a linear path (loops collapse via the
+    caller's coarse guard).
+    """
+    if not events:
+        return []
+
+    # Ordered step sequence: first event's previous_step, then every current_step.
+    seq = []
+    first_prev = (events[0].event_data or {}).get("previous_step")
+    if first_prev:
+        seq.append(first_prev)
+    for e in events:
+        cur = (e.event_data or {}).get("current_step")
+        seq.append(cur)
+
+    failed = set(instance.failed_steps or [])
+    skipped = set(instance.skipped_steps or [])
+    instance_completed = instance.status == "completed"
+
+    reconstructed = []
+    for i, step_id in enumerate(seq):
+        if not step_id:
+            continue
+        # Transition INTO this step.
+        started_at = instance.started_at if i == 0 else events[i - 1].timestamp
+        # Transition OUT of this step.
+        if i < len(events):
+            completed_at = events[i].timestamp
+        else:
+            # Final step: only reliable when the instance actually finished.
+            if not instance_completed or not instance.completed_at:
+                continue
+            completed_at = instance.completed_at
+
+        if not started_at or not completed_at:
+            continue
+
+        if step_id in failed:
+            status = "failed"
+        elif step_id in skipped:
+            status = "skipped"
+        else:
+            status = "completed"
+
+        reconstructed.append((step_id, started_at, completed_at, status))
+
+    return reconstructed
+
+
+async def backfill(workflow_id=None, dry_run=False, batch_size=500):
+    query = {"event_type": EventType.STEP_ADVANCED}
+    if workflow_id:
+        query["workflow_id"] = workflow_id
+
+    events = await WorkflowEvent.find(query).sort("+instance_id", "+timestamp").to_list()
+
+    events_by_instance = defaultdict(list)
+    for e in events:
+        if e.instance_id:
+            events_by_instance[e.instance_id].append(e)
+
+    print(f"Found {len(events)} STEP_ADVANCED events across {len(events_by_instance)} instances"
+          + (f" for workflow {workflow_id}" if workflow_id else ""))
+
+    instances_scanned = 0
+    instances_skipped_no_instance = 0
+    rows_written = 0
+    rows_skipped_existing = 0
+
+    for instance_id, inst_events in events_by_instance.items():
+        instance = await WorkflowInstance.find_one(WorkflowInstance.instance_id == instance_id)
+        if not instance:
+            instances_skipped_no_instance += 1
+            continue
+        instances_scanned += 1
+
+        # Coarse idempotency guard: step_ids already recorded for this instance.
+        existing = await StepExecution.find(StepExecution.instance_id == instance_id).to_list()
+        seen_steps = {se.step_id for se in existing}
+
+        for step_id, started_at, completed_at, status in _reconstruct_steps(instance, inst_events):
+            if step_id in seen_steps:
+                rows_skipped_existing += 1
+                continue
+            seen_steps.add(step_id)
+            if dry_run:
+                rows_written += 1
+                continue
+            await StepExecutionService.upsert_step_execution(
+                instance_id=instance_id,
+                step_id=step_id,
+                workflow_id=instance.workflow_id,
+                status=status,
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+            rows_written += 1
+
+    verb = "would write" if dry_run else "wrote"
+    print("---")
+    print(f"Instances scanned:          {instances_scanned}")
+    print(f"Instances skipped (missing): {instances_skipped_no_instance}")
+    print(f"StepExecution rows {verb}:   {rows_written}")
+    print(f"Rows skipped (already present): {rows_skipped_existing}")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Backfill StepExecution rows from STEP_ADVANCED events")
+    parser.add_argument("--workflow-id", default=None, help="Restrict to a single workflow_id")
+    parser.add_argument("--dry-run", action="store_true", help="Report counts without writing")
+    parser.add_argument("--batch-size", type=int, default=500, help="Reserved for future batching")
+    args = parser.parse_args()
+
+    await connect_to_mongo()
+    print("Connected to MongoDB")
+    try:
+        await backfill(workflow_id=args.workflow_id, dry_run=args.dry_run, batch_size=args.batch_size)
+    finally:
+        await close_mongo_connection()
+        print("Disconnected")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Qué

- El ejecutor ahora persiste un `StepExecution` en cada transición terminal (duración real por paso).
- Fix de correctitud en `dag.py`: preservar `started_at` en ciclos waiting/resume para medir el tiempo de permanencia real (p.ej. la espera de validación administrativa).
- Nuevo endpoint `GET /performance/workflows/{id}/analytics`: KPIs de eficiencia, cuellos de botella por paso, distribución de estados y volumen en el tiempo, con aggregation pipelines nativas de Mongo.
- Script `scripts/backfill_step_executions.py` para reconstruir `StepExecution` histórico desde eventos `STEP_ADVANCED`.

## Pruebas

- Endpoint probado contra Mongo real del tenant conapesca (HTTP 200, datos reales).
- Backfill ejecutado: 48 filas históricas; `administrative_validation` emerge como cuello de botella (P95 ~2.1 h).
- E2E ciudadano→revisor (`test_tramite_admin_validation_e2e.py`, TRAMITE=sustitucion): una instancia nueva avanzó un paso real y el ejecutor persistió `StepExecution{pick_concesion, dur=2.15s}` en vivo.