### PR TITLE
fix(executor): reconstruir con execution.outputs (no .output)

### DIFF
--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -339,7 +339,7 @@ class WorkflowService:
                     "status": execution.status,
                     "started_at": execution.started_at.isoformat() if execution.started_at else None,
                     "completed_at": execution.completed_at.isoformat() if execution.completed_at else None,
-                    "result": execution.output
+                    "result": execution.outputs
                 }
 
             # Mark completed steps


### PR DESCRIPTION
## Bug

`reconstruct_instance_from_db` leía `execution.output` (el campo del modelo es `outputs`), lanzando `AttributeError` que el `except` capturaba devolviendo `None`. El bug estaba **latente**: `step_executions` siempre estaba vacío, así que ese loop nunca se ejecutaba.

Al empezar a persistir `StepExecution` por paso (#32) + el backfill, toda instancia con ≥1 paso completado dejó de reconstruirse → `get_instance` devolvía `None` → el trámite se quedaba en **"Procesando su solicitud… Preparando el siguiente paso"** sin avanzar (síntoma: arranca, pide entidades en el picker, y ya no avanza).

## Fix

`execution.output` → `execution.outputs` (una línea).

## Verificación

Instancia real atorada (`aviso_arribo_electronico`, 1 step_execution): antes `get_instance -> None`; con el fix `get_instance -> OK (reconstructed)`, `current_task=collect_arrival_data`. Backend local reiniciado con el fix ya la reconstruye.